### PR TITLE
Fix Piper logging and add conversation context

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -43,10 +43,9 @@ projects:
         sync: false
       - key: EBIRD_MCP_URL
         sync: false
-      - key: PYTHONUNBUFFERED
-        value: "1"
+
       region: oregon
       dockerContext: .
       dockerfilePath: ./Dockerfile
-      dockerCommand: uv run python3 -m cloaca.piper.main
+      dockerCommand: uv run python3 -u -m cloaca.piper.main
       autoDeployTrigger: checksPass

--- a/src/cloaca/piper/bird_query.py
+++ b/src/cloaca/piper/bird_query.py
@@ -50,12 +50,23 @@ logger = logging.getLogger(__name__)
 client = AsyncAnthropic()
 
 
-async def ask_bird_query(query: str) -> tuple[str, QueryStats]:
+async def ask_bird_query(
+    query: str,
+    prior_messages: list[dict] | None = None,
+    prior_context: str | None = None,
+) -> tuple[str, QueryStats, list[dict]]:
     start = time.monotonic()
     chunks: list[str] = []
     total_input_tokens = 0
     total_output_tokens = 0
     tool_call_count = 0
+
+    if prior_messages:
+        messages = prior_messages + [{"role": "user", "content": query}]
+    elif prior_context:
+        messages = [{"role": "user", "content": f"{prior_context}\n\nNew question: {query}"}]
+    else:
+        messages = [{"role": "user", "content": query}]
 
     async with sse_client(EBIRD_MCP_URL) as (read, write):
         async with ClientSession(read, write) as mcp_client:
@@ -69,7 +80,7 @@ async def ask_bird_query(query: str) -> tuple[str, QueryStats]:
                 thinking={"type": "adaptive"},
                 system=SYSTEM_PROMPT,
                 tools=[async_mcp_tool(t, mcp_client) for t in tools_result.tools],
-                messages=[{"role": "user", "content": query}],
+                messages=messages,
                 stream=True,
             )
 
@@ -93,4 +104,6 @@ async def ask_bird_query(query: str) -> tuple[str, QueryStats]:
         output_tokens=total_output_tokens,
         tool_calls=tool_call_count,
     )
-    return "".join(chunks), stats
+    response_text = "".join(chunks)
+    updated_messages = messages + [{"role": "assistant", "content": response_text}]
+    return response_text, stats, updated_messages

--- a/src/cloaca/piper/bird_query.py
+++ b/src/cloaca/piper/bird_query.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import time
 from dataclasses import dataclass
@@ -44,6 +45,8 @@ class QueryStats:
         return (self.input_tokens * 5 + self.output_tokens * 25) / 1_000_000
 
 
+logger = logging.getLogger(__name__)
+
 client = AsyncAnthropic()
 
 
@@ -58,7 +61,7 @@ async def ask_bird_query(query: str) -> tuple[str, QueryStats]:
         async with ClientSession(read, write) as mcp_client:
             await mcp_client.initialize()
             tools_result = await mcp_client.list_tools()
-            print(f"[bird_query] Connected, {len(tools_result.tools)} tools")
+            logger.info("Connected, %d tools", len(tools_result.tools))
 
             runner = client.beta.messages.tool_runner(
                 model="claude-sonnet-4-6",
@@ -75,18 +78,14 @@ async def ask_bird_query(query: str) -> tuple[str, QueryStats]:
                     if event.type == "content_block_stop":
                         if event.content_block.type == "tool_use":
                             tool_call_count += 1
-                            print(
-                                f"[bird_query] tool_call: {event.content_block.name} input={event.content_block.input}"
-                            )
+                            logger.info("tool_call: %s input=%s", event.content_block.name, event.content_block.input)
                     elif event.type == "text":
                         chunks.append(event.text)
 
                 final = await message_stream.get_final_message()
                 total_input_tokens += final.usage.input_tokens
                 total_output_tokens += final.usage.output_tokens
-                print(
-                    f"[bird_query] turn done: stop_reason={final.stop_reason}, output_tokens={final.usage.output_tokens}"
-                )
+                logger.info("turn done: stop_reason=%s, output_tokens=%d", final.stop_reason, final.usage.output_tokens)
 
     stats = QueryStats(
         elapsed_s=time.monotonic() - start,

--- a/src/cloaca/piper/main.py
+++ b/src/cloaca/piper/main.py
@@ -1,8 +1,11 @@
+import logging
 import os
 
 import discord
 
 from cloaca.piper.bird_query import ask_bird_query
+
+logging.basicConfig(level=logging.INFO)
 
 intents = discord.Intents.default()
 intents.message_content = True

--- a/src/cloaca/piper/main.py
+++ b/src/cloaca/piper/main.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 
 import discord
 
@@ -8,32 +9,101 @@ from cloaca.piper.bird_query import ask_bird_query
 logging.basicConfig(level=logging.INFO)
 logging.getLogger("httpx").setLevel(logging.WARNING)
 
+logger = logging.getLogger(__name__)
+
 intents = discord.Intents.default()
 intents.message_content = True
 
 bot = discord.Client(intents=intents)
 
+# Maps bot reply message ID -> full messages list for that conversation turn
+CACHE_MAX_SIZE = 50
+conversation_cache: dict[int, list[dict]] = {}
+
+
+def cache_put(message_id: int, messages: list[dict]) -> None:
+    if len(conversation_cache) >= CACHE_MAX_SIZE:
+        oldest = next(iter(conversation_cache))
+        del conversation_cache[oldest]
+    conversation_cache[message_id] = messages
+
+
+async def build_prior_context(ref_msg: discord.Message) -> str:
+    """Walk reply chain up to 5 messages and return a plain-text summary."""
+    turns = []
+    msg = ref_msg
+    depth = 0
+
+    while msg is not None and depth < 5:
+        if msg.author == bot.user:
+            content = re.sub(r"\n\n-#.*$", "", msg.content, flags=re.DOTALL).strip()
+            turns.insert(0, f"Piper: {content}")
+        else:
+            content = msg.content.replace(f"<@{bot.user.id}>", "").replace(f"<@!{bot.user.id}>", "").strip()
+            turns.insert(0, f"User: {content}")
+
+        if msg.reference is not None:
+            try:
+                msg = await msg.channel.fetch_message(msg.reference.message_id)
+            except discord.NotFound:
+                break
+        else:
+            msg = None
+        depth += 1
+
+    if not turns:
+        return ""
+    return "[Prior conversation — reconstructed from Discord, not current session:]\n" + "\n\n".join(turns)
+
 
 @bot.event
 async def on_ready():
-    print(f"[piper] online as {bot.user}")
+    logger.info("online as %s", bot.user)
 
 
 @bot.event
 async def on_message(message: discord.Message):
     if message.author == bot.user:
         return
-    if bot.user not in message.mentions:
+
+    is_mention = bot.user in message.mentions
+    is_reply = message.reference is not None
+
+    if not is_mention and not is_reply:
         return
 
-    query = message.content.replace(f"<@{bot.user.id}>", "").replace(f"<@!{bot.user.id}>", "").strip()
+    # If it's a reply, check whether it's a reply to the bot
+    ref_msg = None
+    if is_reply:
+        try:
+            ref_msg = await message.channel.fetch_message(message.reference.message_id)
+        except discord.NotFound:
+            pass
+        if ref_msg is not None and ref_msg.author != bot.user:
+            ref_msg = None  # reply to someone else
+            if not is_mention:
+                return  # not mentioned either, ignore
 
+    query = message.content.replace(f"<@{bot.user.id}>", "").replace(f"<@!{bot.user.id}>", "").strip()
     if not query:
         await message.reply("What birds are you curious about?")
         return
 
+    # Build context from cache or reply chain
+    prior_messages = None
+    prior_context = None
+    if ref_msg is not None:
+        if ref_msg.id in conversation_cache:
+            prior_messages = conversation_cache[ref_msg.id]
+            logger.info("cache hit for message %d (%d prior messages)", ref_msg.id, len(prior_messages))
+        else:
+            prior_context = await build_prior_context(ref_msg)
+            logger.info("cache miss for message %d, built context from reply chain", ref_msg.id)
+
     async with message.channel.typing():
-        response, stats = await ask_bird_query(query)
+        response, stats, updated_messages = await ask_bird_query(
+            query, prior_messages=prior_messages, prior_context=prior_context
+        )
 
     footer = (
         f"-# {stats.elapsed_s:.0f}s · "
@@ -41,9 +111,9 @@ async def on_message(message: discord.Message):
         f"${stats.cost_usd:.3f} · "
         f"{stats.tool_calls} tool call{'s' if stats.tool_calls != 1 else ''}"
     )
-
     body = response or "Sorry, I couldn't find anything on that."
-    await message.reply(f"{body}\n\n{footer}")
+    reply = await message.reply(f"{body}\n\n{footer}")
+    cache_put(reply.id, updated_messages)
 
 
 bot.run(os.environ["PIPER_DISCORD_BOT_TOKEN"])

--- a/src/cloaca/piper/main.py
+++ b/src/cloaca/piper/main.py
@@ -89,6 +89,11 @@ async def on_message(message: discord.Message):
         await message.reply("What birds are you curious about?")
         return
 
+    if ref_msg is not None:
+        logger.info("query (reply to %d): %s", ref_msg.id, query)
+    else:
+        logger.info("query: %s", query)
+
     # Build context from cache or reply chain
     prior_messages = None
     prior_context = None

--- a/src/cloaca/piper/main.py
+++ b/src/cloaca/piper/main.py
@@ -6,6 +6,7 @@ import discord
 from cloaca.piper.bird_query import ask_bird_query
 
 logging.basicConfig(level=logging.INFO)
+logging.getLogger("httpx").setLevel(logging.WARNING)
 
 intents = discord.Intents.default()
 intents.message_content = True


### PR DESCRIPTION
## Summary

- Switch `print()` to Python `logging` module so logs appear in Render (stderr vs buffered stdout)
- Suppress noisy `httpx` INFO logs
- Add conversation context: cache full message history keyed by bot reply ID, fall back to walking the Discord reply chain (up to 5 messages) if cache misses
- Respond to replies to the bot's messages, not just explicit mentions
- Log user queries and whether they're a reply to a prior message

## Test plan

- [ ] Mention the bot and confirm logs show the query
- [ ] Reply to the bot's response and confirm `cache hit` in logs and Claude has context
- [ ] Restart the bot and reply to an old message — confirm `cache miss` and fallback to reply chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)