### PR TITLE
add DuckDB MCP server for local hotspot queries

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -43,6 +43,8 @@ projects:
         sync: false
       - key: EBIRD_MCP_URL
         sync: false
+      - key: DUCK_DB_PATH
+        value: /var/data/parsed_full_sorted.db
 
       region: oregon
       dockerContext: .

--- a/render.yaml
+++ b/render.yaml
@@ -50,4 +50,8 @@ projects:
       dockerContext: .
       dockerfilePath: ./Dockerfile
       dockerCommand: uv run python3 -u -m cloaca.piper.main
+      disk:
+        name: disk
+        mountPath: /var/data
+        sizeGB: 1
       autoDeployTrigger: checksPass

--- a/src/cloaca/piper/bird_query.py
+++ b/src/cloaca/piper/bird_query.py
@@ -1,12 +1,14 @@
 import logging
 import os
 import time
+from contextlib import AsyncExitStack
 from dataclasses import dataclass
 
 from anthropic import AsyncAnthropic
 from anthropic.lib.tools.mcp import async_mcp_tool
-from mcp import ClientSession
+from mcp import ClientSession, StdioServerParameters
 from mcp.client.sse import sse_client
+from mcp.client.stdio import stdio_client
 
 EBIRD_MCP_URL = os.environ["EBIRD_MCP_URL"]
 
@@ -30,7 +32,23 @@ Your response will be displayed in Discord. Use Discord-appropriate formatting:
 - Prospect Park: L109516
 - Green-Wood Cemetery: L285884
 - McGolrick Park: L2987624
-- Franz Sigel Park: L1814508"""
+- Franz Sigel Park: L1814508
+
+## Local Bird Database (DuckDB)
+You have tools to query a local database of bird observation data.
+
+**`list_tables` / `list_columns`** — use these first to explore available tables and their schemas.
+
+**`execute_query`** — run read-only SQL (DuckDB dialect). Results capped at 1024 rows.
+
+**`localities_hotspots` table** — monthly hotspot stats per locality. Good for:
+- Finding hotspots by name (fuzzy search with ILIKE)
+- Ranking hotspots by diversity (`common_and_uncommon_species`) or activity (`avg_weekly_number_of_observations`) for a given month
+- Looking up a locality_id when you only know the name
+
+Columns: `locality_id`, `locality_name`, `latitude`, `longitude`, `locality_type`, `month` (1–12), `avg_weekly_number_of_observations`, `common_species`, `uncommon_species`, `common_and_uncommon_species`
+
+**Do NOT use the local DB for recent sightings** — use the eBird API tools for that."""
 
 
 @dataclass
@@ -68,35 +86,54 @@ async def ask_bird_query(
     else:
         messages = [{"role": "user", "content": query}]
 
-    async with sse_client(EBIRD_MCP_URL) as (read, write):
-        async with ClientSession(read, write) as mcp_client:
-            await mcp_client.initialize()
-            tools_result = await mcp_client.list_tools()
-            logger.info("Connected, %d tools", len(tools_result.tools))
+    duck_db_path = os.environ.get("DUCK_DB_PATH")
 
-            runner = client.beta.messages.tool_runner(
-                model="claude-sonnet-4-6",
-                max_tokens=4096,
-                thinking={"type": "adaptive"},
-                system=SYSTEM_PROMPT,
-                tools=[async_mcp_tool(t, mcp_client) for t in tools_result.tools],
-                messages=messages,
-                stream=True,
+    async with AsyncExitStack() as stack:
+        # eBird SSE connection
+        ebird_read, ebird_write = await stack.enter_async_context(sse_client(EBIRD_MCP_URL))
+        ebird_client = await stack.enter_async_context(ClientSession(ebird_read, ebird_write))
+        await ebird_client.initialize()
+        ebird_tools = await ebird_client.list_tools()
+        logger.info("eBird connected, %d tools", len(ebird_tools.tools))
+
+        tools = [async_mcp_tool(t, ebird_client) for t in ebird_tools.tools]
+
+        # DuckDB stdio connection (optional)
+        if duck_db_path:
+            duck_params = StdioServerParameters(
+                command="uvx",
+                args=["mcp-server-motherduck", "--db-path", duck_db_path],
             )
+            duck_read, duck_write = await stack.enter_async_context(stdio_client(duck_params))
+            duck_client = await stack.enter_async_context(ClientSession(duck_read, duck_write))
+            await duck_client.initialize()
+            duck_tools = await duck_client.list_tools()
+            logger.info("DuckDB connected, %d tools", len(duck_tools.tools))
+            tools += [async_mcp_tool(t, duck_client) for t in duck_tools.tools]
 
-            async for message_stream in runner:
-                async for event in message_stream:
-                    if event.type == "content_block_stop":
-                        if event.content_block.type == "tool_use":
-                            tool_call_count += 1
-                            logger.info("tool_call: %s input=%s", event.content_block.name, event.content_block.input)
-                    elif event.type == "text":
-                        chunks.append(event.text)
+        runner = client.beta.messages.tool_runner(
+            model="claude-sonnet-4-6",
+            max_tokens=4096,
+            thinking={"type": "adaptive"},
+            system=SYSTEM_PROMPT,
+            tools=tools,
+            messages=messages,
+            stream=True,
+        )
 
-                final = await message_stream.get_final_message()
-                total_input_tokens += final.usage.input_tokens
-                total_output_tokens += final.usage.output_tokens
-                logger.info("turn done: stop_reason=%s, output_tokens=%d", final.stop_reason, final.usage.output_tokens)
+        async for message_stream in runner:
+            async for event in message_stream:
+                if event.type == "content_block_stop":
+                    if event.content_block.type == "tool_use":
+                        tool_call_count += 1
+                        logger.info("tool_call: %s input=%s", event.content_block.name, event.content_block.input)
+                elif event.type == "text":
+                    chunks.append(event.text)
+
+            final = await message_stream.get_final_message()
+            total_input_tokens += final.usage.input_tokens
+            total_output_tokens += final.usage.output_tokens
+            logger.info("turn done: stop_reason=%s, output_tokens=%d", final.stop_reason, final.usage.output_tokens)
 
     stats = QueryStats(
         elapsed_s=time.monotonic() - start,

--- a/src/cloaca/piper/cli.py
+++ b/src/cloaca/piper/cli.py
@@ -1,0 +1,19 @@
+import asyncio
+import sys
+
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
+from cloaca.piper.bird_query import ask_bird_query
+
+
+async def main():
+    query = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else input("Query: ")
+    print(f">>> {query}\n")
+    response, stats, _ = await ask_bird_query(query)
+    print(response)
+    print(f"\n[{stats.elapsed_s:.1f}s · {stats.input_tokens + stats.output_tokens:,} tokens · ${stats.cost_usd:.3f} · {stats.tool_calls} tool calls]")
+
+
+asyncio.run(main())


### PR DESCRIPTION
## Summary
- Connects piper to `mcp-server-motherduck` via stdio alongside the existing eBird SSE connection, using `AsyncExitStack` to manage both cleanly
- Adds `localities_hotspots` guidance to the system prompt (hotspot diversity rankings, name→locality_id lookups)
- Adds `src/cloaca/piper/cli.py` for local testing (`uv run python -m cloaca.piper.cli "..."`)
- Adds `DUCK_DB_PATH` env var to piper worker in `render.yaml`; DuckDB connection is optional — piper degrades gracefully without it

`mcp-server-motherduck` runs read-only by default, so no write risk.  `uvx` is already available in the Docker image.

## Test plan
- [ ] `uv run python -m cloaca.piper.cli "what is the most species-diverse hotspot in Brooklyn in May?"` — should call `execute_query` against `localities_hotspots`
- [ ] `uv run python -m cloaca.piper.cli "what notable birds have been seen in Central Park today?"` — should use eBird API only
- [ ] `uv run python -m cloaca.piper.cli "what is the capital of France?"` — should decline politely
- [ ] Confirm piper deploys and connects to Discord on Render after `DUCK_DB_PATH` is set in the piper worker env

🤖 Generated with [Claude Code](https://claude.com/claude-code)