### PR TITLE
Add ebd_nyc table and update piper to use it

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -44,7 +44,7 @@ projects:
       - key: EBIRD_MCP_URL
         sync: false
       - key: DUCK_DB_PATH
-        value: /var/data/parsed_full_sorted.db
+        value: /var/data/ebd_nyc.db
 
       region: oregon
       dockerContext: .

--- a/src/cloaca/piper/bird_query.py
+++ b/src/cloaca/piper/bird_query.py
@@ -35,18 +35,30 @@ Your response will be displayed in Discord. Use Discord-appropriate formatting:
 - Franz Sigel Park: L1814508
 
 ## Local Bird Database (DuckDB)
-You have tools to query a local database of bird observation data.
+You have tools to query a local database of NYC eBird observation data.
 
-**`list_tables` / `list_columns`** — use these first to explore available tables and their schemas.
+**`execute_query`** — run read-only SQL (DuckDB dialect).
 
-**`execute_query`** — run read-only SQL (DuckDB dialect). Results capped at 1024 rows.
+**`ebd_nyc` table** — 14.7M eBird observation records for the five NYC boroughs (Manhattan, Brooklyn, Queens, Bronx, Staten Island), covering all years through Jan 2026. Sorted by `locality_id, observation_date` for efficient filtering. Good for:
+- Arrival/departure timing for a species at a specific location
+- Historical frequency trends
+- Comparing species across locations or time periods
 
-**`localities_hotspots` table** — monthly hotspot stats per locality. Good for:
-- Finding hotspots by name (fuzzy search with ILIKE)
-- Ranking hotspots by diversity (`common_and_uncommon_species`) or activity (`avg_weekly_number_of_observations`) for a given month
-- Looking up a locality_id when you only know the name
+Key columns:
+- `common_name` — e.g. `'Eastern Phoebe'`
+- `scientific_name`
+- `observation_date` — DATE type; use `YEAR()`, `MONTH()`, `DAYOFYEAR()` for date math
+- `observation_count` — VARCHAR (can be `'X'` for presence-only); cast to INTEGER carefully
+- `locality_id` — eBird hotspot/location ID (e.g. `'L2987624'`)
+- `locality` — location name (use `ILIKE '%name%'` for fuzzy search)
+- `county_code` — `'US-NY-061'` Manhattan, `'US-NY-047'` Brooklyn, `'US-NY-081'` Queens, `'US-NY-005'` Bronx, `'US-NY-085'` Staten Island
+- `approved` — BOOLEAN; always filter `WHERE approved = true`
+- `all_species_reported` — BOOLEAN; filter `= true` for complete checklists when computing absence
+- `sampling_event_identifier` — checklist ID; use `COUNT(DISTINCT ...)` to count checklists
+- `category` — ENUM: `'species'`, `'issf'`, `'spuh'`, `'slash'`, `'hybrid'`, `'form'`, `'domestic'`, `'intergrade'`
+- `protocol_name`, `duration_minutes`, `effort_distance_km`, `number_observers`
 
-Columns: `locality_id`, `locality_name`, `latitude`, `longitude`, `locality_type`, `month` (1–12), `avg_weekly_number_of_observations`, `common_species`, `uncommon_species`, `common_and_uncommon_species`
+**Arrival queries**: group by year, take `MIN(observation_date)` per year, filter `MONTH() BETWEEN 1 AND 6` for spring. Use percentiles across years for a typical range.
 
 **Do NOT use the local DB for recent sightings** — use the eBird API tools for that."""
 

--- a/src/cloaca/swan_lake/scripts/build_ebd_nyc.py
+++ b/src/cloaca/swan_lake/scripts/build_ebd_nyc.py
@@ -1,0 +1,130 @@
+"""
+Build the ebd_nyc table from the full EBD source database.
+
+Reads from the external drive source DB and writes an optimized,
+NYC-only table to a local output DB.
+
+Usage:
+    uv run python src/cloaca/swan_lake/scripts/build_ebd_nyc.py \
+        --source /Volumes/lacie_disk/ebd_relJan-2026.db \
+        --output src/cloaca/swan_lake/dbs/ebd_nyc.db
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+
+NYC_COUNTIES = ("US-NY-061", "US-NY-047", "US-NY-081", "US-NY-005", "US-NY-085")
+
+# fmt: off
+SQL_TEMPLATE = """
+ATTACH '{source}' AS src (READ_ONLY);
+SET enable_progress_bar = true;
+
+CREATE TYPE IF NOT EXISTS category_t      AS ENUM ('species','issf','spuh','slash','hybrid','form','domestic','intergrade');
+CREATE TYPE IF NOT EXISTS exotic_code_t   AS ENUM ('N','X','P');
+CREATE TYPE IF NOT EXISTS locality_type_t AS ENUM ('C','H','P','PC','S','T');
+CREATE TYPE IF NOT EXISTS protocol_t      AS ENUM ('Area','Banding','Breeding Bird Atlas','Historical','Incidental','My Yard Counts','Nocturnal Flight Call Count','Random','Stationary','Stationary (2 band, 100m)','Stationary (2 band, 25m)','Stationary (2 band, 30m)','Stationary (2 band, 50m)','Stationary (2 band, 75m)','Stationary (3 band, 30m+100m)','Stationary (Directional)','Traveling','Traveling (2 band, 25m)','Traveling - Property Specific','eBird Pelagic Protocol');
+
+CREATE TABLE ebd_nyc AS
+SELECT
+    category::category_t                                    AS category,
+    common_name,
+    scientific_name,
+    subspecies_common_name,
+    subspecies_scientific_name,
+    exotic_code::exotic_code_t                              AS exotic_code,
+    observation_count,
+    country_code,
+    state_code,
+    county_code,
+    locality,
+    locality_id,
+    locality_type::locality_type_t                          AS locality_type,
+    latitude::FLOAT                                         AS latitude,
+    longitude::FLOAT                                        AS longitude,
+    observation_date,
+    sampling_event_identifier,
+    protocol_name::protocol_t                               AS protocol_name,
+    duration_minutes::INTEGER                               AS duration_minutes,
+    effort_distance_km::FLOAT                               AS effort_distance_km,
+    number_observers::SMALLINT                              AS number_observers,
+    all_species_reported,
+    group_identifier,
+    approved,
+    reviewed
+FROM src.ebd_full
+WHERE county_code IN ('US-NY-061','US-NY-047','US-NY-081','US-NY-005','US-NY-085')
+{order_by}{limit};
+
+SELECT COUNT(*) AS row_count FROM ebd_nyc;
+"""
+# fmt: on
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", default="/Volumes/lacie_disk/ebd_relJan-2026.db")
+    parser.add_argument("--output", default="src/cloaca/swan_lake/dbs/ebd_nyc.db")
+    parser.add_argument("--limit", type=int, default=None, help="Limit rows for testing (skips ORDER BY)")
+    args = parser.parse_args()
+
+    if not os.path.exists(args.source):
+        print(f"Source DB not found: {args.source}")
+        sys.exit(1)
+
+    if os.path.exists(args.output):
+        print(f"Output DB already exists: {args.output}")
+        print("Delete it first if you want to rebuild.")
+        sys.exit(1)
+
+    order_by = "" if args.limit else "ORDER BY locality_id, observation_date\n"
+    limit = f"LIMIT {args.limit}" if args.limit else ""
+
+    sql = SQL_TEMPLATE.format(source=args.source, order_by=order_by, limit=limit)
+
+    print(f"Source: {args.source}")
+    print(f"Output: {args.output}")
+    print(f"Filter: {NYC_COUNTIES}")
+    if args.limit:
+        print(f"Limit:  {args.limit:,} rows (test mode — ORDER BY skipped)")
+    print()
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".sql", delete=False) as f:
+        f.write(sql)
+        sql_file = f.name
+
+    def heartbeat(stop: threading.Event):
+        while not stop.wait(30):
+            elapsed = time.time() - start_time
+            print(f"  still running... {elapsed/60:.1f} min elapsed", flush=True)
+
+    print("Starting extraction...")
+    sys.stdout.flush()
+    start_time = time.time()
+    stop_event = threading.Event()
+    watcher = threading.Thread(target=heartbeat, args=(stop_event,), daemon=True)
+    watcher.start()
+    try:
+        result = subprocess.run(
+            ["duckdb", args.output, "-f", sql_file],
+            check=False,
+        )
+    finally:
+        stop_event.set()
+        os.unlink(sql_file)
+
+    if result.returncode != 0:
+        print("Extraction failed.")
+        if os.path.exists(args.output):
+            os.unlink(args.output)
+        sys.exit(1)
+
+    elapsed = time.time() - start_time
+    db_size_mb = os.path.getsize(args.output) / 1024 / 1024
+    print(f"\nDone in {elapsed/60:.1f} minutes")
+    print(f"DB size: {db_size_mb:.1f} MB")

--- a/src/cloaca/swan_lake/scripts/build_ebd_nyc.sh
+++ b/src/cloaca/swan_lake/scripts/build_ebd_nyc.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+set -e
+
+usage() {
+    echo "Usage: $0 --source <source.db> --output <output.db> [--limit N]"
+    echo ""
+    echo "  --source  Path to full EBD source DB (default: /Volumes/lacie_disk/ebd_relJan-2026.db)"
+    echo "  --output  Path to write NYC DB (default: src/cloaca/swan_lake/dbs/ebd_nyc.db)"
+    echo "  --limit   Row limit for testing (skips ORDER BY)"
+    exit 1
+}
+
+SOURCE="/Volumes/lacie_disk/ebd_relJan-2026.db"
+OUTPUT="src/cloaca/swan_lake/dbs/ebd_nyc.db"
+LIMIT=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --source) SOURCE="$2"; shift 2 ;;
+        --output) OUTPUT="$2"; shift 2 ;;
+        --limit)  LIMIT="$2"; shift 2 ;;
+        *) usage ;;
+    esac
+done
+
+if [ ! -f "$SOURCE" ]; then
+    echo "Error: source DB not found: $SOURCE"
+    exit 1
+fi
+
+if [ -f "$OUTPUT" ]; then
+    echo "Error: output DB already exists: $OUTPUT"
+    echo "Delete it first if you want to rebuild."
+    exit 1
+fi
+
+ORDER_BY="ORDER BY locality_id, observation_date"
+LIMIT_CLAUSE=""
+if [ -n "$LIMIT" ]; then
+    ORDER_BY=""
+    LIMIT_CLAUSE="LIMIT $LIMIT"
+    echo "Mode:   test (limit $LIMIT rows, ORDER BY skipped)"
+fi
+
+echo "Source: $SOURCE"
+echo "Output: $OUTPUT"
+echo ""
+
+SETUP_SQL="
+CREATE TYPE IF NOT EXISTS category_t      AS ENUM ('species','issf','spuh','slash','hybrid','form','domestic','intergrade');
+CREATE TYPE IF NOT EXISTS exotic_code_t   AS ENUM ('N','X','P');
+CREATE TYPE IF NOT EXISTS locality_type_t AS ENUM ('C','H','P','PC','S','T');
+CREATE TYPE IF NOT EXISTS protocol_t      AS ENUM ('Area','Banding','Breeding Bird Atlas','Historical','Incidental','My Yard Counts','Nocturnal Flight Call Count','Random','Stationary','Stationary (2 band, 100m)','Stationary (2 band, 25m)','Stationary (2 band, 30m)','Stationary (2 band, 50m)','Stationary (2 band, 75m)','Stationary (3 band, 30m+100m)','Stationary (Directional)','Traveling','Traveling (2 band, 25m)','Traveling - Property Specific','eBird Pelagic Protocol');
+"
+
+
+CREATE_SQL="
+CREATE TABLE ebd_nyc AS
+SELECT
+    category::category_t                    AS category,
+    common_name,
+    scientific_name,
+    subspecies_common_name,
+    subspecies_scientific_name,
+    exotic_code::exotic_code_t              AS exotic_code,
+    observation_count,
+    country_code,
+    state_code,
+    county_code,
+    locality,
+    locality_id,
+    locality_type::locality_type_t          AS locality_type,
+    latitude::FLOAT                         AS latitude,
+    longitude::FLOAT                        AS longitude,
+    observation_date,
+    sampling_event_identifier,
+    protocol_name::protocol_t               AS protocol_name,
+    duration_minutes::INTEGER               AS duration_minutes,
+    effort_distance_km::FLOAT               AS effort_distance_km,
+    number_observers::SMALLINT              AS number_observers,
+    all_species_reported,
+    group_identifier,
+    approved,
+    reviewed
+FROM src.ebd_full
+WHERE county_code IN ('US-NY-061','US-NY-047','US-NY-081','US-NY-005','US-NY-085')
+$ORDER_BY
+$LIMIT_CLAUSE
+"
+
+INIT_FILE=$(mktemp /tmp/duckdb_init.XXXXXX.sql)
+cat > "$INIT_FILE" <<EOF
+ATTACH '$SOURCE' AS src (READ_ONLY);
+SET enable_progress_bar = true;
+EOF
+
+START=$(date +%s)
+duckdb "$OUTPUT" -c "$SETUP_SQL"
+if ! duckdb "$OUTPUT" -init "$INIT_FILE" -c "$CREATE_SQL"; then
+    echo "Error: duckdb failed"
+    rm -f "$OUTPUT" "$INIT_FILE"
+    exit 1
+fi
+rm -f "$INIT_FILE"
+
+duckdb "$OUTPUT" -c "SELECT COUNT(*) AS row_count FROM ebd_nyc;"
+
+END=$(date +%s)
+ELAPSED=$(( (END - START) / 60 ))
+SIZE=$(du -sh "$OUTPUT" | cut -f1)
+
+echo ""
+echo "Done in ${ELAPSED} minutes"
+echo "DB size: $SIZE"


### PR DESCRIPTION
## Summary
- Adds build scripts to extract an optimized NYC-only EBD table (`ebd_nyc`) from the full 2.1B-row global dataset — ENUMs + type downgrades reduce size ~76% (288MB, 14.7M rows)
- Updates piper system prompt with full `ebd_nyc` schema docs so Claude can answer historical/phenology questions (arrival timing, frequency trends, etc.)
- Updates `DUCK_DB_PATH` in `render.yaml` to point to `ebd_nyc.db` on the piper disk

## Test plan
- [ ] Upload `ebd_nyc.db` to piper Render disk: `scp -s src/cloaca/swan_lake/dbs/ebd_nyc.db srv-d6s2eh94tr6s73cfesc0@ssh.oregon.render.com:/var/data/ebd_nyc.db`
- [ ] Deploy and confirm piper logs show "DuckDB connected, N tools"
- [ ] Ask piper a phenology question (e.g. "when do Eastern Phoebes typically arrive in McGolrick Park?") and verify it queries `ebd_nyc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)