### PR TITLE
Run piper inside cloaca instead of as a separate worker

### DIFF
--- a/.claude/skills/infra.md
+++ b/.claude/skills/infra.md
@@ -1,0 +1,51 @@
+---
+name: infra
+description: How to deploy, manage services, and work with Render infrastructure for the birds-eye-app project.
+---
+
+# Infrastructure
+
+## Services on Render
+
+All services run in the **Oregon** region under the "Birds Eye" project in David Meadows's workspace.
+
+| Service | Type | Repo | Branch | Deploy trigger |
+|---------|------|------|--------|----------------|
+| **cloaca** | Web service (Docker) | `birds-eye-app/cloaca` | `main` | checksPass |
+| **beak-v2** | Static site | `birds-eye-app/beak-v2` | `main` | commit |
+
+- **cloaca** is the main API server (FastAPI). Piper (Discord bot) runs inside cloaca as an asyncio background task.
+- **beak-v2** is the frontend.
+
+To find service IDs, run: `render services --confirm -o json` or check memory.
+
+## Deploying from a branch
+
+To deploy a specific branch/commit to a service without merging to main:
+
+```bash
+# Get the commit SHA
+git rev-parse HEAD
+
+# Deploy it (the commit must be pushed to the remote first)
+render deploys create <service-id> --commit <sha> --confirm -o json
+
+# Check deploy status
+render deploys list <service-id> --confirm -o json
+
+# View logs from a specific time
+render logs -r <service-id> --start "<ISO timestamp>" -o text --confirm
+```
+
+## Render disk
+
+Cloaca has a 1GB persistent disk mounted at `/var/data`. This holds the `ebd_nyc.db` DuckDB database used by piper for local bird observation queries. To upload files to it, use `scp` via Render SSH (see memory for the exact command).
+
+## Environment variables
+
+Managed per-service in the Render dashboard. Key ones for cloaca+piper:
+- `ANTHROPIC_API_KEY` -- Claude API access for piper
+- `PIPER_DISCORD_BOT_TOKEN` -- Discord bot token
+- `EBIRD_MCP_URL` -- eBird MCP server endpoint
+- `PIPER_DUCK_DB_PATH` -- path to DuckDB on the Render disk (`/var/data/ebd_nyc.db`)
+- `DUCK_DB_PATH` -- path to cloaca's own DuckDB for hotspot queries

--- a/.claude/skills/infra.md
+++ b/.claude/skills/infra.md
@@ -47,5 +47,5 @@ Managed per-service in the Render dashboard. Key ones for cloaca+piper:
 - `ANTHROPIC_API_KEY` -- Claude API access for piper
 - `PIPER_DISCORD_BOT_TOKEN` -- Discord bot token
 - `EBIRD_MCP_URL` -- eBird MCP server endpoint
-- `PIPER_DUCK_DB_PATH` -- path to DuckDB on the Render disk (`/var/data/ebd_nyc.db`)
-- `DUCK_DB_PATH` -- path to cloaca's own DuckDB for hotspot queries
+- `PIPER_DUCK_DB_PATH` -- path to the eBird observation database on the Render disk (`/var/data/ebd_nyc.db`), used by piper via MCP
+- `DUCK_DB_PATH` -- path to cloaca's own DuckDB for hotspot queries (separate database from piper's)

--- a/render.yaml
+++ b/render.yaml
@@ -19,37 +19,20 @@ projects:
         sync: false
       - key: DUCK_DB_PATH
         sync: false
+      - key: PIPER_DUCK_DB_PATH
+        value: /var/data/ebd_nyc.db
       - key: EBIRD_API_KEY
         sync: false
-      region: oregon
-      healthCheckPath: /v1/health
-      dockerContext: .
-      dockerfilePath: ./Dockerfile
-      disk:
-        name: disk
-        mountPath: /var/data
-        sizeGB: 1
-      autoDeployTrigger: checksPass
-
-    - type: worker
-      name: piper
-      runtime: docker
-      repo: https://github.com/birds-eye-app/cloaca
-      plan: starter
-      envVars:
       - key: ANTHROPIC_API_KEY
         sync: false
       - key: PIPER_DISCORD_BOT_TOKEN
         sync: false
       - key: EBIRD_MCP_URL
         sync: false
-      - key: DUCK_DB_PATH
-        value: /var/data/ebd_nyc.db
-
       region: oregon
+      healthCheckPath: /v1/health
       dockerContext: .
       dockerfilePath: ./Dockerfile
-      dockerCommand: uv run python3 -u -m cloaca.piper.main
       disk:
         name: disk
         mountPath: /var/data

--- a/src/cloaca/main.py
+++ b/src/cloaca/main.py
@@ -129,17 +129,25 @@ async def get_popular_hotspots_endpoint(
 
 
 # this is deprecated but I can't find another way to use the "repeat every" util without it
+_piper_task: asyncio.Task | None = None
+
+
 @Cloaca_App.on_event("startup")
 async def start_piper():
-    if is_dev:
-        print("skipping piper in dev mode")
-        return
+    global _piper_task
     token = os.getenv("PIPER_DISCORD_BOT_TOKEN")
     if not token:
         print("PIPER_DISCORD_BOT_TOKEN not set, skipping piper")
         return
     from cloaca.piper.main import start as piper_start
-    asyncio.create_task(piper_start())
+
+    async def _run_piper():
+        try:
+            await piper_start()
+        except Exception as e:
+            print(f"piper crashed: {e}")
+
+    _piper_task = asyncio.create_task(_run_piper())
     print("piper started")
 
 
@@ -178,7 +186,10 @@ async def shutdown_event():
             print("DuckDB connection closed.")
         except Exception as e:
             print("Error closing DuckDB connection:", e)
-    from cloaca.piper.main import bot
-    if not bot.is_closed():
-        await bot.close()
+    if _piper_task is not None:
+        from cloaca.piper.main import bot
+        from cloaca.piper.bird_query import close_duck_conn
+        if not bot.is_closed():
+            await bot.close()
+        await close_duck_conn()
         print("piper stopped")

--- a/src/cloaca/main.py
+++ b/src/cloaca/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import time
 from typing import Dict, List, Any
@@ -129,6 +130,20 @@ async def get_popular_hotspots_endpoint(
 
 # this is deprecated but I can't find another way to use the "repeat every" util without it
 @Cloaca_App.on_event("startup")
+async def start_piper():
+    if is_dev:
+        print("skipping piper in dev mode")
+        return
+    token = os.getenv("PIPER_DISCORD_BOT_TOKEN")
+    if not token:
+        print("PIPER_DISCORD_BOT_TOKEN not set, skipping piper")
+        return
+    from cloaca.piper.main import start as piper_start
+    asyncio.create_task(piper_start())
+    print("piper started")
+
+
+@Cloaca_App.on_event("startup")
 @repeat_every(seconds=60 * 60 * 1)  # every hour
 async def refresh_regional_lifers():
     # dont do this on startup in local dev to not spam ebird
@@ -163,3 +178,7 @@ async def shutdown_event():
             print("DuckDB connection closed.")
         except Exception as e:
             print("Error closing DuckDB connection:", e)
+    from cloaca.piper.main import bot
+    if not bot.is_closed():
+        await bot.close()
+        print("piper stopped")

--- a/src/cloaca/main.py
+++ b/src/cloaca/main.py
@@ -142,10 +142,18 @@ async def start_piper():
     from cloaca.piper.main import start as piper_start
 
     async def _run_piper():
-        try:
-            await piper_start()
-        except Exception as e:
-            print(f"piper crashed: {e}")
+        delay = 5
+        while True:
+            try:
+                await piper_start()
+            except asyncio.CancelledError:
+                return
+            except Exception as e:
+                print(f"piper crashed: {e}, restarting in {delay}s")
+                await asyncio.sleep(delay)
+                delay = min(delay * 2, 300)
+            else:
+                return
 
     _piper_task = asyncio.create_task(_run_piper())
     print("piper started")
@@ -189,7 +197,13 @@ async def shutdown_event():
     if _piper_task is not None:
         from cloaca.piper.main import bot
         from cloaca.piper.bird_query import close_duck_conn
+
         if not bot.is_closed():
             await bot.close()
+        _piper_task.cancel()
+        try:
+            await _piper_task
+        except asyncio.CancelledError:
+            pass
         await close_duck_conn()
         print("piper stopped")

--- a/src/cloaca/piper/bird_query.py
+++ b/src/cloaca/piper/bird_query.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import time
@@ -9,6 +10,61 @@ from anthropic.lib.tools.mcp import async_mcp_tool
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
+
+_DUCK_IDLE_SECONDS = 5 * 60
+_duck_lock = asyncio.Lock()
+_duck_conn: "_CachedDuckConn | None" = None
+
+
+class _CachedDuckConn:
+    def __init__(self, stack: AsyncExitStack, session: ClientSession, tools: list):
+        self.stack = stack
+        self.session = session
+        self.tools = tools
+        self._timer: asyncio.Task | None = None
+
+    def reset_timer(self) -> None:
+        if self._timer:
+            self._timer.cancel()
+        self._timer = asyncio.create_task(self._idle_close())
+
+    async def _idle_close(self) -> None:
+        global _duck_conn
+        await asyncio.sleep(_DUCK_IDLE_SECONDS)
+        async with _duck_lock:
+            await self.stack.aclose()
+            if _duck_conn is self:
+                _duck_conn = None
+        logger.info("DuckDB MCP closed after %ds idle", _DUCK_IDLE_SECONDS)
+
+
+async def _get_duck_conn(duck_db_path: str) -> _CachedDuckConn:
+    global _duck_conn
+    async with _duck_lock:
+        if _duck_conn is not None:
+            _duck_conn.reset_timer()
+            logger.info("reusing DuckDB MCP connection")
+            return _duck_conn
+
+        stack = AsyncExitStack()
+        await stack.__aenter__()
+        try:
+            params = StdioServerParameters(
+                command="uvx",
+                args=["mcp-server-motherduck", "--db-path", duck_db_path],
+            )
+            read, write = await stack.enter_async_context(stdio_client(params))
+            session = await stack.enter_async_context(ClientSession(read, write))
+            await session.initialize()
+            tools = (await session.list_tools()).tools
+            logger.info("DuckDB MCP connected, %d tools", len(tools))
+        except Exception:
+            await stack.aclose()
+            raise
+
+        _duck_conn = _CachedDuckConn(stack, session, tools)
+        _duck_conn.reset_timer()
+        return _duck_conn
 
 EBIRD_MCP_URL = os.environ["EBIRD_MCP_URL"]
 
@@ -98,7 +154,7 @@ async def ask_bird_query(
     else:
         messages = [{"role": "user", "content": query}]
 
-    duck_db_path = os.environ.get("DUCK_DB_PATH")
+    duck_db_path = os.environ.get("PIPER_DUCK_DB_PATH")
 
     async with AsyncExitStack() as stack:
         # eBird SSE connection
@@ -110,18 +166,10 @@ async def ask_bird_query(
 
         tools = [async_mcp_tool(t, ebird_client) for t in ebird_tools.tools]
 
-        # DuckDB stdio connection (optional)
+        # DuckDB stdio connection (cached, idle TTL)
         if duck_db_path:
-            duck_params = StdioServerParameters(
-                command="uvx",
-                args=["mcp-server-motherduck", "--db-path", duck_db_path],
-            )
-            duck_read, duck_write = await stack.enter_async_context(stdio_client(duck_params))
-            duck_client = await stack.enter_async_context(ClientSession(duck_read, duck_write))
-            await duck_client.initialize()
-            duck_tools = await duck_client.list_tools()
-            logger.info("DuckDB connected, %d tools", len(duck_tools.tools))
-            tools += [async_mcp_tool(t, duck_client) for t in duck_tools.tools]
+            duck = await _get_duck_conn(duck_db_path)
+            tools += [async_mcp_tool(t, duck.session) for t in duck.tools]
 
         runner = client.beta.messages.tool_runner(
             model="claude-sonnet-4-6",

--- a/src/cloaca/piper/bird_query.py
+++ b/src/cloaca/piper/bird_query.py
@@ -22,6 +22,14 @@ class _CachedDuckConn:
         self.session = session
         self.tools = tools
         self._timer: asyncio.Task | None = None
+        self._use_count: int = 0
+
+    def acquire(self) -> None:
+        self._use_count += 1
+
+    def release(self) -> None:
+        self._use_count -= 1
+        self.reset_timer()
 
     def reset_timer(self) -> None:
         if self._timer:
@@ -32,6 +40,8 @@ class _CachedDuckConn:
         global _duck_conn
         await asyncio.sleep(_DUCK_IDLE_SECONDS)
         async with _duck_lock:
+            if self._use_count > 0:
+                return
             await self.stack.aclose()
             if _duck_conn is self:
                 _duck_conn = None
@@ -66,6 +76,7 @@ async def _get_duck_conn(duck_db_path: str) -> _CachedDuckConn:
         _duck_conn.reset_timer()
         return _duck_conn
 
+
 async def close_duck_conn() -> None:
     global _duck_conn
     async with _duck_lock:
@@ -75,6 +86,7 @@ async def close_duck_conn() -> None:
             await _duck_conn.stack.aclose()
             _duck_conn = None
             logger.info("DuckDB MCP closed on shutdown")
+
 
 EBIRD_MCP_URL = os.environ.get("EBIRD_MCP_URL", "")
 
@@ -151,6 +163,8 @@ async def ask_bird_query(
     prior_messages: list[dict] | None = None,
     prior_context: str | None = None,
 ) -> tuple[str, QueryStats, list[dict]]:
+    if not EBIRD_MCP_URL:
+        raise RuntimeError("EBIRD_MCP_URL is not set")
     start = time.monotonic()
     chunks: list[str] = []
     total_input_tokens = 0
@@ -160,7 +174,9 @@ async def ask_bird_query(
     if prior_messages:
         messages = prior_messages + [{"role": "user", "content": query}]
     elif prior_context:
-        messages = [{"role": "user", "content": f"{prior_context}\n\nNew question: {query}"}]
+        messages = [
+            {"role": "user", "content": f"{prior_context}\n\nNew question: {query}"}
+        ]
     else:
         messages = [{"role": "user", "content": query}]
 
@@ -168,8 +184,12 @@ async def ask_bird_query(
 
     async with AsyncExitStack() as stack:
         # eBird SSE connection
-        ebird_read, ebird_write = await stack.enter_async_context(sse_client(EBIRD_MCP_URL))
-        ebird_client = await stack.enter_async_context(ClientSession(ebird_read, ebird_write))
+        ebird_read, ebird_write = await stack.enter_async_context(
+            sse_client(EBIRD_MCP_URL)
+        )
+        ebird_client = await stack.enter_async_context(
+            ClientSession(ebird_read, ebird_write)
+        )
         await ebird_client.initialize()
         ebird_tools = await ebird_client.list_tools()
         logger.info("eBird connected, %d tools", len(ebird_tools.tools))
@@ -177,33 +197,47 @@ async def ask_bird_query(
         tools = [async_mcp_tool(t, ebird_client) for t in ebird_tools.tools]
 
         # DuckDB stdio connection (cached, idle TTL)
+        duck: _CachedDuckConn | None = None
         if duck_db_path:
             duck = await _get_duck_conn(duck_db_path)
+            duck.acquire()
             tools += [async_mcp_tool(t, duck.session) for t in duck.tools]
 
-        runner = client.beta.messages.tool_runner(
-            model="claude-sonnet-4-6",
-            max_tokens=4096,
-            thinking={"type": "adaptive"},
-            system=SYSTEM_PROMPT,
-            tools=tools,
-            messages=messages,
-            stream=True,
-        )
+        try:
+            runner = client.beta.messages.tool_runner(
+                model="claude-sonnet-4-6",
+                max_tokens=4096,
+                thinking={"type": "adaptive"},
+                system=SYSTEM_PROMPT,
+                tools=tools,
+                messages=messages,
+                stream=True,
+            )
 
-        async for message_stream in runner:
-            async for event in message_stream:
-                if event.type == "content_block_stop":
-                    if event.content_block.type == "tool_use":
-                        tool_call_count += 1
-                        logger.info("tool_call: %s input=%s", event.content_block.name, event.content_block.input)
-                elif event.type == "text":
-                    chunks.append(event.text)
+            async for message_stream in runner:
+                async for event in message_stream:
+                    if event.type == "content_block_stop":
+                        if event.content_block.type == "tool_use":
+                            tool_call_count += 1
+                            logger.info(
+                                "tool_call: %s input=%s",
+                                event.content_block.name,
+                                event.content_block.input,
+                            )
+                    elif event.type == "text":
+                        chunks.append(event.text)
 
-            final = await message_stream.get_final_message()
-            total_input_tokens += final.usage.input_tokens
-            total_output_tokens += final.usage.output_tokens
-            logger.info("turn done: stop_reason=%s, output_tokens=%d", final.stop_reason, final.usage.output_tokens)
+                final = await message_stream.get_final_message()
+                total_input_tokens += final.usage.input_tokens
+                total_output_tokens += final.usage.output_tokens
+                logger.info(
+                    "turn done: stop_reason=%s, output_tokens=%d",
+                    final.stop_reason,
+                    final.usage.output_tokens,
+                )
+        finally:
+            if duck is not None:
+                duck.release()
 
     stats = QueryStats(
         elapsed_s=time.monotonic() - start,

--- a/src/cloaca/piper/bird_query.py
+++ b/src/cloaca/piper/bird_query.py
@@ -66,7 +66,17 @@ async def _get_duck_conn(duck_db_path: str) -> _CachedDuckConn:
         _duck_conn.reset_timer()
         return _duck_conn
 
-EBIRD_MCP_URL = os.environ["EBIRD_MCP_URL"]
+async def close_duck_conn() -> None:
+    global _duck_conn
+    async with _duck_lock:
+        if _duck_conn is not None:
+            if _duck_conn._timer:
+                _duck_conn._timer.cancel()
+            await _duck_conn.stack.aclose()
+            _duck_conn = None
+            logger.info("DuckDB MCP closed on shutdown")
+
+EBIRD_MCP_URL = os.environ.get("EBIRD_MCP_URL", "")
 
 SYSTEM_PROMPT = """You are a birding assistant for New York City. You answer questions about bird sightings, eBird observations, hotspots, and birding topics — but only for NYC and the surrounding area (the five boroughs, Long Island, New Jersey, Connecticut, and the lower Hudson Valley).
 

--- a/src/cloaca/piper/main.py
+++ b/src/cloaca/piper/main.py
@@ -121,4 +121,10 @@ async def on_message(message: discord.Message):
     cache_put(reply.id, updated_messages)
 
 
-bot.run(os.environ["PIPER_DISCORD_BOT_TOKEN"])
+async def start():
+    await bot.start(os.environ["PIPER_DISCORD_BOT_TOKEN"])
+
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(start())

--- a/src/cloaca/piper/main.py
+++ b/src/cloaca/piper/main.py
@@ -56,9 +56,17 @@ async def build_prior_context(ref_msg: discord.Message) -> str:
     return "[Prior conversation — reconstructed from Discord, not current session:]\n" + "\n\n".join(turns)
 
 
+PIPER_BOT_UPDATES_CHANNEL_ID = 1492206410711433397
+
+
 @bot.event
 async def on_ready():
     logger.info("online as %s", bot.user)
+    channel = bot.get_channel(PIPER_BOT_UPDATES_CHANNEL_ID)
+    if channel:
+        await channel.send("I'm up!")
+    else:
+        logger.warning("could not find startup channel %d", PIPER_BOT_UPDATES_CHANNEL_ID)
 
 
 @bot.event


### PR DESCRIPTION
## Summary
- Launches the piper Discord bot as an asyncio background task during FastAPI startup instead of running it as a separate Render worker service
- Removes the standalone `piper` worker from `render.yaml`, merges its env vars into the `cloaca` web service
- Adds error handling for the piper task, guarded shutdown cleanup, and a cached DuckDB MCP connection with idle TTL
- Piper posts "I'm up!" to #piper-bot-updates on startup

## Test plan
- [x] Verified locally — piper connects to Discord and posts startup message
- [ ] Confirm Render deploy succeeds and health check passes
- [ ] Confirm "I'm up!" appears in #piper-bot-updates from production
- [ ] Test a bird query in Discord to confirm piper responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)