### PR TITLE
add daily BirdCast migration forecast

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "twilio>=9.8.0",
     "anthropic[mcp]>=0.84.0",
     "discord-py>=2.7.1",
+    "aiohttp>=3.9.0",
 ]
 readme = "README.md"
 requires-python = ">= 3.9"

--- a/src/cloaca/piper/birdcast.py
+++ b/src/cloaca/piper/birdcast.py
@@ -1,0 +1,116 @@
+import datetime
+import logging
+import os
+import random
+
+import aiohttp
+import discord
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+BIRDCAST_API_BASE = (
+    "https://alert.birdcast.org/api/is-birdcast-alert-api"
+    "/40.7127753,-74.0059728/birdcast"
+)
+BIRDCAST_PAGE_URL = (
+    "https://alert.birdcast.org/"
+    "?latLng=40.7127753,-74.0059728"
+    "&locName=New%20York,%20NY,%20USA"
+)
+BIRDCAST_CHANNEL_ID = 1492204794931052666
+
+BIRD_EMOJIS = [
+    "\U0001f426",  # bird
+    "\U0001f985",  # eagle
+    "\U0001f989",  # owl
+    "\U0001f99c",  # parrot
+    "\U0001f9a9",  # flamingo
+    "\U0001f427",  # penguin
+    "\U0001fab6",  # feather
+    "\U0001f54a\ufe0f",  # dove
+    "\U0001f423",  # hatching chick
+    "\U0001fabd",  # wing
+]
+
+CODE_TO_TIER = {
+    1: ("Low", "\U0001f535"),  # blue circle
+    2: ("Medium", "\U0001f7e1"),  # yellow circle
+    3: ("High", "\U0001f534"),  # red circle
+}
+
+
+class ForecastNight(BaseModel):
+    date: datetime.datetime
+    total: int
+    code: int
+
+
+class BirdcastForecast(BaseModel):
+    generatedDate: datetime.datetime
+    forecastNights: list[ForecastNight]
+
+
+async def fetch_birdcast_forecast() -> BirdcastForecast | None:
+    key = os.environ.get("BIRDCAST_API_KEY")
+    if not key:
+        logger.warning("BIRDCAST_API_KEY not set, skipping forecast")
+        return None
+    url = f"{BIRDCAST_API_BASE}?key={key}"
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as resp:
+            if resp.status != 200:
+                logger.warning("BirdCast API returned %d", resp.status)
+                return None
+            data = await resp.json()
+    try:
+        return BirdcastForecast.model_validate(data)
+    except Exception:
+        logger.exception("failed to parse BirdCast response")
+        return None
+
+
+def format_forecast_message(forecast: BirdcastForecast) -> str:
+    birds = random.sample(BIRD_EMOJIS, 4)
+    header = f"{birds[0]}{birds[1]} **Migration Update** {birds[2]}{birds[3]}"
+    lines = [header + "\n"]
+
+    for i, night in enumerate(forecast.forecastNights):
+        date_str = night.date.strftime("%b %-d")
+
+        if i == 0:
+            label = f"Tonight ({date_str})"
+        elif i == 1:
+            label = f"Tomorrow ({date_str})"
+        else:
+            label = f"{night.date.strftime('%A')} ({date_str})"
+
+        tier, emoji = CODE_TO_TIER.get(night.code, ("Unknown", "\u26aa"))
+        lines.append(f"{emoji} **{label}:** {tier}")
+
+    return "\n".join(lines)
+
+
+def birdcast_link_view() -> discord.ui.View:
+    view = discord.ui.View()
+    view.add_item(
+        discord.ui.Button(
+            style=discord.ButtonStyle.link,
+            label="View on BirdCast",
+            url=BIRDCAST_PAGE_URL,
+        )
+    )
+    return view
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    async def _main():
+        data = await fetch_birdcast_forecast()
+        if data is None:
+            print("Failed to fetch forecast")
+            return
+        print(format_forecast_message(data))
+
+    asyncio.run(_main())

--- a/src/cloaca/piper/main.py
+++ b/src/cloaca/piper/main.py
@@ -1,10 +1,18 @@
+import datetime
 import logging
 import os
 import re
 
 import discord
+from discord.ext import tasks
 
 from cloaca.piper.bird_query import ask_bird_query
+from cloaca.piper.birdcast import (
+    BIRDCAST_CHANNEL_ID,
+    birdcast_link_view,
+    fetch_birdcast_forecast,
+    format_forecast_message,
+)
 
 logging.basicConfig(level=logging.INFO)
 logging.getLogger("httpx").setLevel(logging.WARNING)
@@ -39,7 +47,11 @@ async def build_prior_context(ref_msg: discord.Message) -> str:
             content = re.sub(r"\n\n-#.*$", "", msg.content, flags=re.DOTALL).strip()
             turns.insert(0, f"Piper: {content}")
         else:
-            content = msg.content.replace(f"<@{bot.user.id}>", "").replace(f"<@!{bot.user.id}>", "").strip()
+            content = (
+                msg.content.replace(f"<@{bot.user.id}>", "")
+                .replace(f"<@!{bot.user.id}>", "")
+                .strip()
+            )
             turns.insert(0, f"User: {content}")
 
         if msg.reference is not None:
@@ -53,10 +65,28 @@ async def build_prior_context(ref_msg: discord.Message) -> str:
 
     if not turns:
         return ""
-    return "[Prior conversation — reconstructed from Discord, not current session:]\n" + "\n\n".join(turns)
+    return (
+        "[Prior conversation — reconstructed from Discord, not current session:]\n"
+        + "\n\n".join(turns)
+    )
 
 
 PIPER_BOT_UPDATES_CHANNEL_ID = 1492206410711433397
+
+
+@tasks.loop(time=datetime.time(hour=22, minute=0, tzinfo=datetime.timezone.utc))
+async def post_birdcast_forecast():
+    channel = bot.get_channel(BIRDCAST_CHANNEL_ID)
+    if channel is None:
+        logger.warning("could not find birdcast channel %d", BIRDCAST_CHANNEL_ID)
+        return
+    forecast = await fetch_birdcast_forecast()
+    if forecast is None or not forecast.forecastNights:
+        logger.info("no birdcast forecast available, skipping")
+        return
+    message = format_forecast_message(forecast)
+    await channel.send(message, view=birdcast_link_view())
+    logger.info("posted birdcast forecast")
 
 
 @bot.event
@@ -66,7 +96,11 @@ async def on_ready():
     if channel:
         await channel.send("I'm up!")
     else:
-        logger.warning("could not find startup channel %d", PIPER_BOT_UPDATES_CHANNEL_ID)
+        logger.warning(
+            "could not find startup channel %d", PIPER_BOT_UPDATES_CHANNEL_ID
+        )
+    if not post_birdcast_forecast.is_running():
+        post_birdcast_forecast.start()
 
 
 @bot.event
@@ -92,7 +126,11 @@ async def on_message(message: discord.Message):
             if not is_mention:
                 return  # not mentioned either, ignore
 
-    query = message.content.replace(f"<@{bot.user.id}>", "").replace(f"<@!{bot.user.id}>", "").strip()
+    query = (
+        message.content.replace(f"<@{bot.user.id}>", "")
+        .replace(f"<@!{bot.user.id}>", "")
+        .strip()
+    )
     if not query:
         await message.reply("What birds are you curious about?")
         return
@@ -108,10 +146,16 @@ async def on_message(message: discord.Message):
     if ref_msg is not None:
         if ref_msg.id in conversation_cache:
             prior_messages = conversation_cache[ref_msg.id]
-            logger.info("cache hit for message %d (%d prior messages)", ref_msg.id, len(prior_messages))
+            logger.info(
+                "cache hit for message %d (%d prior messages)",
+                ref_msg.id,
+                len(prior_messages),
+            )
         else:
             prior_context = await build_prior_context(ref_msg)
-            logger.info("cache miss for message %d, built context from reply chain", ref_msg.id)
+            logger.info(
+                "cache miss for message %d, built context from reply chain", ref_msg.id
+            )
 
     async with message.channel.typing():
         response, stats, updated_messages = await ask_bird_query(
@@ -135,4 +179,5 @@ async def start():
 
 if __name__ == "__main__":
     import asyncio
+
     asyncio.run(start())

--- a/uv.lock
+++ b/uv.lock
@@ -575,6 +575,7 @@ name = "cloaca"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiohttp" },
     { name = "anthropic", extra = ["mcp"] },
     { name = "discord-py" },
     { name = "duckdb" },
@@ -595,6 +596,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiohttp", specifier = ">=3.9.0" },
     { name = "anthropic", extras = ["mcp"], specifier = ">=0.84.0" },
     { name = "discord-py", specifier = ">=2.7.1" },
     { name = "duckdb", specifier = ">=1.3.2" },


### PR DESCRIPTION
## Summary
- Adds a daily BirdCast migration forecast post to #bird-cast-updates at 6 PM ET
- Fetches 3-night forecast (tonight, tomorrow, next day) from BirdCast API for NYC
- Color-coded tiers: 🔵 Low, 🟡 Medium, 🔴 High
- Includes a "View on BirdCast" link button (no embed unfurl)
- Random bird emoji decoration in the header for fun

## Test plan
- [x] Tested locally via `uv run python -m cloaca.piper.birdcast`
- [x] Sent test messages to #bird-cast-updates via Discord bot
- [ ] Verify scheduled task fires at 22:00 UTC after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)