### PR TITLE
add year lifer tracking for McGolrick Park and Franz Sigel Park

### DIFF
--- a/.claude/skills/render-infra.md
+++ b/.claude/skills/render-infra.md
@@ -1,0 +1,83 @@
+---
+name: render-infra
+description: How to deploy, manage services, and work with Render infrastructure for the birds-eye-app project.
+---
+
+# Infrastructure
+
+## Services on Render
+
+All services run in the **Oregon** region under the "Birds Eye" project in David Meadows's workspace.
+
+| Service | Type | Repo | Branch | Deploy trigger |
+|---------|------|------|--------|----------------|
+| **cloaca** | Web service (Docker) | `birds-eye-app/cloaca` | `main` | checksPass |
+| **beak-v2** | Static site | `birds-eye-app/beak-v2` | `main` | commit |
+
+- **cloaca** is the main API server (FastAPI). Piper (Discord bot) runs inside cloaca as an asyncio background task.
+- **beak-v2** is the frontend.
+
+To find service IDs, run: `render services --confirm -o json` or check memory.
+
+## Deploying from a branch
+
+To deploy a specific branch/commit to a service without merging to main:
+
+```bash
+# Get the commit SHA
+git rev-parse HEAD
+
+# Deploy it (the commit must be pushed to the remote first)
+render deploys create <service-id> --commit <sha> --confirm -o json
+
+# Check deploy status
+render deploys list <service-id> --confirm -o json
+
+# View logs from a specific time
+render logs -r <service-id> --start "<ISO timestamp>" -o text --confirm
+```
+
+To monitor a deploy until it finishes, use a Monitor with a poll loop:
+
+```bash
+while true; do
+  deploy_status=$(render deploys list <service-id> --output json 2>/dev/null \
+    | python3 -c "import json,sys; print(json.load(sys.stdin)[0]['status'])" 2>/dev/null)
+  echo "Deploy: $deploy_status"
+  case "$deploy_status" in
+    live|deactivated|build_failed|update_failed|canceled)
+      echo "Deploy finished: $deploy_status"; break ;;
+  esac
+  sleep 30
+done
+```
+
+After a deploy goes live, verify the health check and tail logs:
+
+```bash
+# Health check
+curl -s https://cloaca.onrender.com/v1/health
+
+# Tail recent logs (last 5 minutes)
+render logs -r <service-id> --start "$(date -u -v-5M +%Y-%m-%dT%H:%M:%SZ)" -o text --confirm
+```
+
+## Render disk
+
+Cloaca has a 1GB persistent disk mounted at `/var/data`. This holds:
+- `ebd_nyc.db` — read-only eBird observation database used by piper via MCP
+- `piper_state.db` — writable state DB for year lifer tracking (auto-created on first startup)
+
+DuckDB note: only one process can hold a write connection. The year lifers code runs `FORCE CHECKPOINT` after writes so SSH readers (using `read_only=True`) can see the data.
+
+To upload files to the disk, use `scp` via Render SSH (see memory for the exact command).
+
+## Environment variables
+
+Managed per-service in the Render dashboard. Key ones for cloaca+piper:
+- `ANTHROPIC_API_KEY` -- Claude API access for piper
+- `PIPER_DISCORD_BOT_TOKEN` -- Discord bot token
+- `EBIRD_MCP_URL` -- eBird MCP server endpoint
+- `PIPER_DUCK_DB_PATH` -- path to the eBird observation database on the Render disk (`/var/data/ebd_nyc.db`), used by piper via MCP
+- `PIPER_STATE_DB_PATH` -- writable DuckDB for piper state (year lifers tracking) on the Render disk (`/var/data/piper_state.db`)
+- `DUCK_DB_PATH` -- path to cloaca's own DuckDB for hotspot queries (separate database from piper's)

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ wheels/
 .vscode/*
 .env
 src/cloaca/swan_lake/dbs/*
+piper_state.db

--- a/render.yaml
+++ b/render.yaml
@@ -21,6 +21,8 @@ projects:
         sync: false
       - key: PIPER_DUCK_DB_PATH
         value: /var/data/ebd_nyc.db
+      - key: PIPER_STATE_DB_PATH
+        value: /var/data/piper_state.db
       - key: EBIRD_API_KEY
         sync: false
       - key: ANTHROPIC_API_KEY

--- a/src/cloaca/main.py
+++ b/src/cloaca/main.py
@@ -206,4 +206,7 @@ async def shutdown_event():
         except asyncio.CancelledError:
             pass
         await close_duck_conn()
+        from cloaca.piper.year_lifers import close_state_db
+
+        close_state_db()
         print("piper stopped")

--- a/src/cloaca/piper/CLAUDE.md
+++ b/src/cloaca/piper/CLAUDE.md
@@ -35,6 +35,27 @@ The DuckDB MCP server (mcp-server-motherduck) is spawned as a subprocess. To avo
 - A 5-minute idle timer that closes the subprocess when unused
 - A global lock for thread-safe access
 
+### Year lifer tracking
+
+`year_lifers.py` tracks first-of-year species sightings at McGolrick Park (hotspot `L2987624`). It uses the eBird historic observations API (`detail=full`, `rank=create`) which returns observer names — the standard recent observations endpoint does not.
+
+**State DB**: A separate writable DuckDB file (`PIPER_STATE_DB_PATH`) stores a `hotspot_year_species` table with species code, first observation date, observer name, and checklist ID. This is independent of the large read-only `ebd_nyc.db`.
+
+**Backfill**: On first startup (when the table is empty for the current year), iterates Jan 1 through yesterday calling the eBird API day-by-day (~100 calls, 0.5s delay between each). Subsequent startups skip this.
+
+**Polling**: Every 15 minutes, fetches observations for today and yesterday (2 API calls). During night hours (10pm–6am ET), enforces at least 1 hour between checks. New species are inserted and posted to #mcgolrick-park.
+
+**Year rollover**: On Jan 1, the table is empty for the new year, triggering a backfill of 0 days. The regular poll picks up the first species naturally.
+
+### Scheduled tasks
+
+| Task | Schedule | Channel | Module |
+|------|----------|---------|--------|
+| BirdCast forecast | Daily at 22:00 UTC (6 PM EDT) | #bird-cast-updates | `birdcast.py` |
+| Year lifer check | Every 15 min (hourly at night) | #mcgolrick-park | `year_lifers.py` |
+
+Both are started in `on_ready()` via `discord.ext.tasks.loop`.
+
 ## Environment variables
 
 - `PIPER_DISCORD_BOT_TOKEN` — Discord bot token (required for piper to start)
@@ -72,6 +93,8 @@ uv run python -m cloaca.piper.main
 
 - `PIPER_BOT_UPDATES_CHANNEL_ID` in `main.py` — Discord channel where Piper posts "I'm up!" on startup (#piper-bot-updates)
 - `BIRDCAST_CHANNEL_ID` in `birdcast.py` — Discord channel for daily migration forecasts (#bird-cast-updates)
+- `YEAR_LIFERS_CHANNEL_ID` in `year_lifers.py` — Discord channel for year lifer notifications (#mcgolrick-park)
+- `MCGOLRICK_HOTSPOT_ID` in `year_lifers.py` — eBird hotspot ID for McGolrick Park (`L2987624`)
 - `CACHE_MAX_SIZE` in `main.py` — Max conversation cache entries (50)
 - `_DUCK_IDLE_SECONDS` in `bird_query.py` — DuckDB connection idle timeout (5 min)
 - Claude model used: `claude-sonnet-4-6` (set in `bird_query.py`)

--- a/src/cloaca/piper/CLAUDE.md
+++ b/src/cloaca/piper/CLAUDE.md
@@ -12,7 +12,7 @@ Piper runs inside the cloaca FastAPI server as an asyncio background task (not a
 - `bird_query.py` — Core query logic. Connects to two MCP servers (eBird API via SSE, DuckDB via stdio), builds a tool-augmented Claude conversation, and streams the response. Contains the system prompt and the cached DuckDB connection pool.
 - `birdcast.py` — Daily BirdCast migration forecast. Fetches a 3-night forecast from the BirdCast API for NYC, formats a color-coded Discord message (🔵 Low, 🟡 Medium, 🔴 High), and posts to #bird-cast-updates. Scheduled via `discord.ext.tasks.loop` at 22:00 UTC (6 PM EDT). Response is validated with Pydantic models (`BirdcastForecast`, `ForecastNight`).
 - `cli.py` — Standalone CLI for testing queries without Discord: `uv run python -m cloaca.piper.cli "what warblers are in prospect park?"`
-- `year_lifers.py` — Year lifer tracking for hotspots. Polls the eBird historic observations API every 15 minutes (hourly at night) to detect new species at McGolrick Park. Stores the year's species list in a writable DuckDB state DB (`PIPER_STATE_DB_PATH`). On first run, backfills the current year from the API. Posts Discord notifications when new species are found, including the observer name and checklist link. Reuses `eBirdHistoricFullObservation` from `scripts/fetch_yearly_hotspot_data.py` and `get_phoebe_client()` from `api/shared.py`.
+- `year_lifers.py` — Year lifer tracking for multiple hotspots. Polls the eBird historic observations API every 15 minutes (hourly at night) to detect new species. Stores the year's species list in a writable DuckDB state DB (`PIPER_STATE_DB_PATH`). On first run, backfills the current year from the API for each hotspot. Posts Discord notifications per hotspot channel when new species are found, including the observer name and checklist link. Hotspots are configured via the `WATCHED_HOTSPOTS` list of `Hotspot` dataclasses. Reuses `eBirdHistoricFullObservation` from `scripts/fetch_yearly_hotspot_data.py` and `get_phoebe_client()` from `api/shared.py`.
 
 ### How a query flows
 
@@ -37,13 +37,19 @@ The DuckDB MCP server (mcp-server-motherduck) is spawned as a subprocess. To avo
 
 ### Year lifer tracking
 
-`year_lifers.py` tracks first-of-year species sightings at McGolrick Park (hotspot `L2987624`). It uses the eBird historic observations API (`detail=full`, `rank=create`) which returns observer names — the standard recent observations endpoint does not.
+`year_lifers.py` tracks first-of-year species sightings at watched hotspots. It uses the eBird historic observations API (`detail=full`, `rank=create`) which returns observer names — the standard recent observations endpoint does not.
 
-**State DB**: A separate writable DuckDB file (`PIPER_STATE_DB_PATH`) stores a `hotspot_year_species` table with species code, first observation date, observer name, and checklist ID. This is independent of the large read-only `ebd_nyc.db`.
+**Watched hotspots** are defined in the `WATCHED_HOTSPOTS` list. Each `Hotspot` has an eBird ID, display name, and Discord channel ID. Currently:
+- McGolrick Park (`L2987624`) → #mcgolrick-park
+- Franz Sigel Park (`L1814508`) → #franz-sigel-park
 
-**Backfill**: On first startup (when the table is empty for the current year), iterates Jan 1 through yesterday calling the eBird API day-by-day (~100 calls, 0.5s delay between each). Subsequent startups skip this.
+To add a new hotspot, append a `Hotspot` entry to the list.
 
-**Polling**: Every 15 minutes, fetches observations for today and yesterday (2 API calls). During night hours (10pm–6am ET), enforces at least 1 hour between checks. New species are inserted and posted to #mcgolrick-park.
+**State DB**: A separate writable DuckDB file (`PIPER_STATE_DB_PATH`) stores a `hotspot_year_species` table with species code, first observation date, observer name, and checklist ID. This is independent of the large read-only `ebd_nyc.db`. After writes, `FORCE CHECKPOINT` is called so external readers (e.g. SSH sessions) can see the data.
+
+**Backfill**: On first startup per hotspot (tracked in `backfill_status` table), iterates Jan 1 through yesterday calling the eBird API day-by-day (~100 calls per hotspot, 0.5s delay between each). Subsequent startups skip completed hotspots.
+
+**Polling**: Every 15 minutes, fetches observations for today and yesterday (2 API calls per hotspot). During night hours (10pm–6am ET), enforces at least 1 hour between checks. New species are inserted and posted to the hotspot's Discord channel.
 
 **Year rollover**: On Jan 1, the table is empty for the new year, triggering a backfill of 0 days. The regular poll picks up the first species naturally.
 
@@ -52,7 +58,7 @@ The DuckDB MCP server (mcp-server-motherduck) is spawned as a subprocess. To avo
 | Task | Schedule | Channel | Module |
 |------|----------|---------|--------|
 | BirdCast forecast | Daily at 22:00 UTC (6 PM EDT) | #bird-cast-updates | `birdcast.py` |
-| Year lifer check | Every 15 min (hourly at night) | #mcgolrick-park | `year_lifers.py` |
+| Year lifer check | Every 15 min (hourly at night) | Per hotspot (see `WATCHED_HOTSPOTS`) | `year_lifers.py` |
 
 Both are started in `on_ready()` via `discord.ext.tasks.loop`.
 
@@ -93,8 +99,7 @@ uv run python -m cloaca.piper.main
 
 - `PIPER_BOT_UPDATES_CHANNEL_ID` in `main.py` — Discord channel where Piper posts "I'm up!" on startup (#piper-bot-updates)
 - `BIRDCAST_CHANNEL_ID` in `birdcast.py` — Discord channel for daily migration forecasts (#bird-cast-updates)
-- `YEAR_LIFERS_CHANNEL_ID` in `year_lifers.py` — Discord channel for year lifer notifications (#mcgolrick-park)
-- `MCGOLRICK_HOTSPOT_ID` in `year_lifers.py` — eBird hotspot ID for McGolrick Park (`L2987624`)
+- `WATCHED_HOTSPOTS` in `year_lifers.py` — List of `Hotspot` dataclasses (id, name, channel_id) for year lifer tracking
 - `CACHE_MAX_SIZE` in `main.py` — Max conversation cache entries (50)
 - `_DUCK_IDLE_SECONDS` in `bird_query.py` — DuckDB connection idle timeout (5 min)
 - Claude model used: `claude-sonnet-4-6` (set in `bird_query.py`)

--- a/src/cloaca/piper/CLAUDE.md
+++ b/src/cloaca/piper/CLAUDE.md
@@ -12,6 +12,7 @@ Piper runs inside the cloaca FastAPI server as an asyncio background task (not a
 - `bird_query.py` — Core query logic. Connects to two MCP servers (eBird API via SSE, DuckDB via stdio), builds a tool-augmented Claude conversation, and streams the response. Contains the system prompt and the cached DuckDB connection pool.
 - `birdcast.py` — Daily BirdCast migration forecast. Fetches a 3-night forecast from the BirdCast API for NYC, formats a color-coded Discord message (🔵 Low, 🟡 Medium, 🔴 High), and posts to #bird-cast-updates. Scheduled via `discord.ext.tasks.loop` at 22:00 UTC (6 PM EDT). Response is validated with Pydantic models (`BirdcastForecast`, `ForecastNight`).
 - `cli.py` — Standalone CLI for testing queries without Discord: `uv run python -m cloaca.piper.cli "what warblers are in prospect park?"`
+- `year_lifers.py` — Year lifer tracking for hotspots. Polls the eBird historic observations API every 15 minutes (hourly at night) to detect new species at McGolrick Park. Stores the year's species list in a writable DuckDB state DB (`PIPER_STATE_DB_PATH`). On first run, backfills the current year from the API. Posts Discord notifications when new species are found, including the observer name and checklist link. Reuses `eBirdHistoricFullObservation` from `scripts/fetch_yearly_hotspot_data.py` and `get_phoebe_client()` from `api/shared.py`.
 
 ### How a query flows
 
@@ -41,6 +42,7 @@ The DuckDB MCP server (mcp-server-motherduck) is spawned as a subprocess. To avo
 - `ANTHROPIC_API_KEY` — Claude API key
 - `PIPER_DUCK_DB_PATH` — Path to the ebd_nyc.db DuckDB file (optional; enables historical queries)
 - `BIRDCAST_API_KEY` — API key for BirdCast forecast endpoint (required for daily forecast)
+- `PIPER_STATE_DB_PATH` — Path to the writable DuckDB state file for year lifers (defaults to `piper_state.db`)
 
 ## Local development
 
@@ -54,6 +56,11 @@ uv run python -m cloaca.piper.cli "when do eastern phoebes usually arrive in cen
 To test the BirdCast forecast message locally:
 ```bash
 uv run python -m cloaca.piper.birdcast
+```
+
+To test the year lifers feature (backfill + poll) without Discord:
+```bash
+uv run python -m cloaca.piper.year_lifers
 ```
 
 To run the bot standalone (outside of cloaca):

--- a/src/cloaca/piper/main.py
+++ b/src/cloaca/piper/main.py
@@ -162,14 +162,14 @@ async def on_ready():
                 )
         except Exception:
             logger.exception("failed to backfill year species")
-        # TEMP TEST: delete amerob so the poll detects it as a new year lifer
+        # TEMP FIX: clear state so backfill re-runs with correct dates
+        # (amerob got wrong date from the test notification)
         from cloaca.piper.year_lifers import get_state_db
 
-        get_state_db().execute(
-            "DELETE FROM hotspot_year_species"
-            " WHERE species_code = 'amerob' AND year = 2026"
-        )
-        logger.info("TEMP TEST: deleted amerob to test notification")
+        get_state_db().execute("DELETE FROM hotspot_year_species WHERE year = 2026")
+        get_state_db().execute("DELETE FROM backfill_status WHERE year = 2026")
+        count = await backfill_year_species(MCGOLRICK_HOTSPOT_ID)
+        logger.info("TEMP FIX: re-backfilled %d species with correct dates", count)
         check_year_lifers.start()
 
 

--- a/src/cloaca/piper/main.py
+++ b/src/cloaca/piper/main.py
@@ -162,6 +162,14 @@ async def on_ready():
                 )
         except Exception:
             logger.exception("failed to backfill year species")
+        # TEMP TEST: delete amerob so the poll detects it as a new year lifer
+        from cloaca.piper.year_lifers import get_state_db
+
+        get_state_db().execute(
+            "DELETE FROM hotspot_year_species"
+            " WHERE species_code = 'amerob' AND year = 2026"
+        )
+        logger.info("TEMP TEST: deleted amerob to test notification")
         check_year_lifers.start()
 
 

--- a/src/cloaca/piper/main.py
+++ b/src/cloaca/piper/main.py
@@ -15,9 +15,7 @@ from cloaca.piper.birdcast import (
     format_forecast_message,
 )
 from cloaca.piper.year_lifers import (
-    MCGOLRICK_HOTSPOT_ID,
-    MCGOLRICK_HOTSPOT_NAME,
-    YEAR_LIFERS_CHANNEL_ID,
+    WATCHED_HOTSPOTS,
     backfill_year_species,
     check_for_new_year_lifers,
     format_year_lifer_message,
@@ -93,11 +91,6 @@ _last_year_lifer_check: datetime.datetime | None = None
 async def check_year_lifers():
     global _last_year_lifer_check
 
-    channel = bot.get_channel(YEAR_LIFERS_CHANNEL_ID)
-    if channel is None:
-        logger.warning("could not find year lifers channel %d", YEAR_LIFERS_CHANNEL_ID)
-        return
-
     now = datetime.datetime.now(_EASTERN)
     is_night = now.hour < 6 or now.hour >= 22
 
@@ -108,20 +101,30 @@ async def check_year_lifers():
 
     _last_year_lifer_check = now
 
-    try:
-        new_lifers = await check_for_new_year_lifers(MCGOLRICK_HOTSPOT_ID)
-    except Exception:
-        logger.exception("failed to check year lifers")
-        return
+    for hotspot in WATCHED_HOTSPOTS:
+        channel = bot.get_channel(hotspot.channel_id)
+        if channel is None:
+            logger.warning(
+                "could not find year lifers channel %d for %s",
+                hotspot.channel_id,
+                hotspot.name,
+            )
+            continue
 
-    if not new_lifers:
-        logger.info("no new year lifers")
-        return
+        try:
+            new_lifers = await check_for_new_year_lifers(hotspot.id)
+        except Exception:
+            logger.exception("failed to check year lifers for %s", hotspot.name)
+            continue
 
-    total = get_year_total(MCGOLRICK_HOTSPOT_ID)
-    message = format_year_lifer_message(new_lifers, MCGOLRICK_HOTSPOT_NAME, total)
-    await channel.send(message, view=year_list_link_view(MCGOLRICK_HOTSPOT_ID))
-    logger.info("posted %d new year lifer(s)", len(new_lifers))
+        if not new_lifers:
+            logger.info("no new year lifers at %s", hotspot.name)
+            continue
+
+        total = get_year_total(hotspot.id)
+        message = format_year_lifer_message(new_lifers, hotspot.name, total)
+        await channel.send(message, view=year_list_link_view(hotspot.id))
+        logger.info("posted %d new year lifer(s) for %s", len(new_lifers), hotspot.name)
 
 
 @tasks.loop(time=datetime.time(hour=22, minute=0, tzinfo=datetime.timezone.utc))
@@ -152,24 +155,17 @@ async def on_ready():
     if not post_birdcast_forecast.is_running():
         post_birdcast_forecast.start()
     if not check_year_lifers.is_running():
-        try:
-            count = await backfill_year_species(MCGOLRICK_HOTSPOT_ID)
-            if count > 0:
-                logger.info(
-                    "backfilled %d year species for %s",
-                    count,
-                    MCGOLRICK_HOTSPOT_ID,
-                )
-        except Exception:
-            logger.exception("failed to backfill year species")
-        # TEMP FIX: clear state so backfill re-runs with correct dates
-        # (amerob got wrong date from the test notification)
-        from cloaca.piper.year_lifers import get_state_db
-
-        get_state_db().execute("DELETE FROM hotspot_year_species WHERE year = 2026")
-        get_state_db().execute("DELETE FROM backfill_status WHERE year = 2026")
-        count = await backfill_year_species(MCGOLRICK_HOTSPOT_ID)
-        logger.info("TEMP FIX: re-backfilled %d species with correct dates", count)
+        for hotspot in WATCHED_HOTSPOTS:
+            try:
+                count = await backfill_year_species(hotspot.id)
+                if count > 0:
+                    logger.info(
+                        "backfilled %d year species for %s",
+                        count,
+                        hotspot.name,
+                    )
+            except Exception:
+                logger.exception("failed to backfill year species for %s", hotspot.name)
         check_year_lifers.start()
 
 

--- a/src/cloaca/piper/main.py
+++ b/src/cloaca/piper/main.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import os
 import re
+from zoneinfo import ZoneInfo
 
 import discord
 from discord.ext import tasks
@@ -12,6 +13,16 @@ from cloaca.piper.birdcast import (
     birdcast_link_view,
     fetch_birdcast_forecast,
     format_forecast_message,
+)
+from cloaca.piper.year_lifers import (
+    MCGOLRICK_HOTSPOT_ID,
+    MCGOLRICK_HOTSPOT_NAME,
+    YEAR_LIFERS_CHANNEL_ID,
+    backfill_year_species,
+    check_for_new_year_lifers,
+    format_year_lifer_message,
+    get_year_total,
+    year_list_link_view,
 )
 
 logging.basicConfig(level=logging.INFO)
@@ -74,6 +85,45 @@ async def build_prior_context(ref_msg: discord.Message) -> str:
 PIPER_BOT_UPDATES_CHANNEL_ID = 1492206410711433397
 
 
+_EASTERN = ZoneInfo("America/New_York")
+_last_year_lifer_check: datetime.datetime | None = None
+
+
+@tasks.loop(minutes=15)
+async def check_year_lifers():
+    global _last_year_lifer_check
+
+    channel = bot.get_channel(YEAR_LIFERS_CHANNEL_ID)
+    if channel is None:
+        logger.warning("could not find year lifers channel %d", YEAR_LIFERS_CHANNEL_ID)
+        return
+
+    now = datetime.datetime.now(_EASTERN)
+    is_night = now.hour < 6 or now.hour >= 22
+
+    if is_night and _last_year_lifer_check is not None:
+        elapsed = (now - _last_year_lifer_check).total_seconds()
+        if elapsed < 3600:
+            return
+
+    _last_year_lifer_check = now
+
+    try:
+        new_lifers = await check_for_new_year_lifers(MCGOLRICK_HOTSPOT_ID)
+    except Exception:
+        logger.exception("failed to check year lifers")
+        return
+
+    if not new_lifers:
+        logger.info("no new year lifers")
+        return
+
+    total = get_year_total(MCGOLRICK_HOTSPOT_ID)
+    message = format_year_lifer_message(new_lifers, MCGOLRICK_HOTSPOT_NAME, total)
+    await channel.send(message, view=year_list_link_view(MCGOLRICK_HOTSPOT_ID))
+    logger.info("posted %d new year lifer(s)", len(new_lifers))
+
+
 @tasks.loop(time=datetime.time(hour=22, minute=0, tzinfo=datetime.timezone.utc))
 async def post_birdcast_forecast():
     channel = bot.get_channel(BIRDCAST_CHANNEL_ID)
@@ -101,6 +151,18 @@ async def on_ready():
         )
     if not post_birdcast_forecast.is_running():
         post_birdcast_forecast.start()
+    if not check_year_lifers.is_running():
+        try:
+            count = await backfill_year_species(MCGOLRICK_HOTSPOT_ID)
+            if count > 0:
+                logger.info(
+                    "backfilled %d year species for %s",
+                    count,
+                    MCGOLRICK_HOTSPOT_ID,
+                )
+        except Exception:
+            logger.exception("failed to backfill year species")
+        check_year_lifers.start()
 
 
 @bot.event

--- a/src/cloaca/piper/year_lifers.py
+++ b/src/cloaca/piper/year_lifers.py
@@ -1,0 +1,329 @@
+import asyncio
+import datetime
+import logging
+import os
+import random
+from zoneinfo import ZoneInfo
+
+import duckdb
+import discord
+
+from cloaca.api.shared import get_phoebe_client
+from cloaca.piper.birdcast import BIRD_EMOJIS
+from cloaca.scripts.fetch_yearly_hotspot_data import (
+    eBirdHistoricFullObservation,
+    parse_historic_observations_json_text,
+)
+
+logger = logging.getLogger(__name__)
+
+MCGOLRICK_HOTSPOT_ID = "L2987624"
+MCGOLRICK_HOTSPOT_NAME = "McGolrick Park"
+YEAR_LIFERS_CHANNEL_ID = 1492224353537102025
+
+EASTERN = ZoneInfo("America/New_York")
+
+_state_db: duckdb.DuckDBPyConnection | None = None
+
+
+def get_state_db() -> duckdb.DuckDBPyConnection:
+    global _state_db
+    if _state_db is None:
+        path = os.environ.get("PIPER_STATE_DB_PATH", "piper_state.db")
+        _state_db = duckdb.connect(path, read_only=False)
+        _ensure_tables(_state_db)
+    return _state_db
+
+
+def close_state_db():
+    global _state_db
+    if _state_db is not None:
+        _state_db.close()
+        _state_db = None
+
+
+def _ensure_tables(con: duckdb.DuckDBPyConnection):
+    con.execute("""
+        CREATE TABLE IF NOT EXISTS hotspot_year_species (
+            hotspot_id VARCHAR NOT NULL,
+            year INTEGER NOT NULL,
+            species_code VARCHAR NOT NULL,
+            common_name VARCHAR NOT NULL,
+            scientific_name VARCHAR NOT NULL,
+            first_obs_date DATE NOT NULL,
+            observer_name VARCHAR NOT NULL,
+            checklist_id VARCHAR NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (hotspot_id, year, species_code)
+        );
+    """)
+
+
+def get_year_total(hotspot_id: str) -> int:
+    now = datetime.datetime.now(EASTERN)
+    rows = (
+        get_state_db()
+        .execute(
+            "SELECT COUNT(*) FROM hotspot_year_species WHERE hotspot_id = ? AND year = ?",
+            [hotspot_id, now.year],
+        )
+        .fetchone()
+    )
+    return rows[0] if rows else 0
+
+
+def _get_known_species(hotspot_id: str, year: int) -> set[str]:
+    rows = (
+        get_state_db()
+        .execute(
+            "SELECT species_code FROM hotspot_year_species WHERE hotspot_id = ? AND year = ?",
+            [hotspot_id, year],
+        )
+        .fetchall()
+    )
+    return {row[0] for row in rows}
+
+
+def _insert_species(
+    hotspot_id: str,
+    year: int,
+    obs: eBirdHistoricFullObservation,
+):
+    get_state_db().execute(
+        """INSERT INTO hotspot_year_species
+           (hotspot_id, year, species_code, common_name, scientific_name,
+            first_obs_date, observer_name, checklist_id)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT DO NOTHING""",
+        [
+            hotspot_id,
+            year,
+            obs.speciesCode,
+            obs.comName,
+            obs.sciName,
+            obs.obsDt.date(),
+            obs.userDisplayName,
+            obs.checklistId,
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# eBird API
+# ---------------------------------------------------------------------------
+
+
+async def fetch_observations_for_date(
+    hotspot_id: str, date: datetime.date
+) -> list[eBirdHistoricFullObservation]:
+    raw_response = await get_phoebe_client().data.with_raw_response.observations.recent.historic.list(
+        region_code="US-NY",
+        rank="create",
+        y=date.year,
+        m=date.month,
+        d=date.day,
+        cat="species",
+        r=[hotspot_id],
+        detail="full",
+    )
+    text = await raw_response.text()
+    if not text or text.strip() == "[]":
+        return []
+    observations = parse_historic_observations_json_text(text)
+    # Filter out exotics
+    return [o for o in observations if o.exoticCategory != "X"]
+
+
+# ---------------------------------------------------------------------------
+# Backfill
+# ---------------------------------------------------------------------------
+
+
+async def backfill_year_species(hotspot_id: str) -> int:
+    now = datetime.datetime.now(EASTERN)
+    year = now.year
+
+    existing = get_year_total(hotspot_id)
+    if existing > 0:
+        logger.info(
+            "skipping backfill for %s/%d — already have %d species",
+            hotspot_id,
+            year,
+            existing,
+        )
+        return 0
+
+    logger.info("starting year species backfill for %s/%d", hotspot_id, year)
+
+    # earliest_per_species tracks the first observation of each species
+    earliest_per_species: dict[str, eBirdHistoricFullObservation] = {}
+
+    start_date = datetime.date(year, 1, 1)
+    yesterday = now.date() - datetime.timedelta(days=1)
+    current = start_date
+    failed_days = 0
+
+    while current <= yesterday:
+        try:
+            observations = await fetch_observations_for_date(hotspot_id, current)
+            for obs in observations:
+                if obs.speciesCode not in earliest_per_species:
+                    earliest_per_species[obs.speciesCode] = obs
+                elif obs.obsDt < earliest_per_species[obs.speciesCode].obsDt:
+                    earliest_per_species[obs.speciesCode] = obs
+        except Exception:
+            logger.exception("backfill failed for %s on %s", hotspot_id, current)
+            failed_days += 1
+
+        current += datetime.timedelta(days=1)
+        await asyncio.sleep(0.5)
+
+    # Bulk insert
+    for obs in earliest_per_species.values():
+        _insert_species(hotspot_id, year, obs)
+
+    count = len(earliest_per_species)
+    logger.info(
+        "backfill complete for %s/%d: %d species (%d failed days)",
+        hotspot_id,
+        year,
+        count,
+        failed_days,
+    )
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Polling
+# ---------------------------------------------------------------------------
+
+
+async def check_for_new_year_lifers(
+    hotspot_id: str,
+) -> list[eBirdHistoricFullObservation]:
+    now = datetime.datetime.now(EASTERN)
+    today = now.date()
+    yesterday = today - datetime.timedelta(days=1)
+
+    # Fetch observations for today and yesterday
+    observations: list[eBirdHistoricFullObservation] = []
+    for date in (today, yesterday):
+        try:
+            observations.extend(await fetch_observations_for_date(hotspot_id, date))
+        except Exception:
+            logger.exception(
+                "failed to fetch observations for %s on %s", hotspot_id, date
+            )
+
+    if not observations:
+        return []
+
+    known = _get_known_species(hotspot_id, now.year)
+
+    # Group by species, keep earliest observation per species
+    earliest_new: dict[str, eBirdHistoricFullObservation] = {}
+    for obs in observations:
+        if obs.speciesCode in known:
+            continue
+        if obs.speciesCode not in earliest_new:
+            earliest_new[obs.speciesCode] = obs
+        elif obs.obsDt < earliest_new[obs.speciesCode].obsDt:
+            earliest_new[obs.speciesCode] = obs
+
+    if not earliest_new:
+        return []
+
+    # Insert new lifers into DB
+    new_lifers = list(earliest_new.values())
+    for obs in new_lifers:
+        _insert_species(hotspot_id, now.year, obs)
+
+    logger.info(
+        "found %d new year lifer(s) at %s: %s",
+        len(new_lifers),
+        hotspot_id,
+        ", ".join(o.comName for o in new_lifers),
+    )
+    return new_lifers
+
+
+# ---------------------------------------------------------------------------
+# Discord formatting
+# ---------------------------------------------------------------------------
+
+
+def format_year_lifer_message(
+    new_lifers: list[eBirdHistoricFullObservation],
+    hotspot_name: str,
+    year_total: int,
+) -> str:
+    birds = random.sample(BIRD_EMOJIS, min(2, len(BIRD_EMOJIS)))
+
+    if len(new_lifers) == 1:
+        obs = new_lifers[0]
+        date_str = obs.obsDt.strftime("%b %-d")
+        header = f"{birds[0]} **Year Bird #{year_total} for {hotspot_name}!**"
+        checklist_url = f"https://ebird.org/checklist/{obs.checklistId}"
+        body = (
+            f"\U0001f426 **{obs.comName}** — first spotted by "
+            f"{obs.userDisplayName} ({date_str})\n"
+            f"[View checklist]({checklist_url})"
+        )
+        return f"{header}\n\n{body}"
+
+    # Multiple lifers
+    header = (
+        f"{birds[0]}{birds[1]} **{len(new_lifers)} New Year Birds "
+        f"for {hotspot_name}!** (now at {year_total} species)"
+    )
+    lines = [header, ""]
+    for obs in new_lifers:
+        date_str = obs.obsDt.strftime("%b %-d")
+        checklist_url = f"https://ebird.org/checklist/{obs.checklistId}"
+        lines.append(
+            f"\U0001f426 **{obs.comName}** — {obs.userDisplayName} "
+            f"({date_str}) · [checklist]({checklist_url})"
+        )
+    return "\n".join(lines)
+
+
+def year_list_link_view(hotspot_id: str) -> discord.ui.View:
+    view = discord.ui.View()
+    view.add_item(
+        discord.ui.Button(
+            style=discord.ButtonStyle.link,
+            label="View Year List on eBird",
+            url=f"https://ebird.org/hotspot/{hotspot_id}/bird-list?yr=cur",
+        )
+    )
+    return view
+
+
+# ---------------------------------------------------------------------------
+# CLI testing
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    from dotenv import load_dotenv
+
+    load_dotenv(override=True)
+    logging.basicConfig(level=logging.INFO)
+
+    async def _main():
+        count = await backfill_year_species(MCGOLRICK_HOTSPOT_ID)
+        print(f"Backfilled {count} species")
+
+        total = get_year_total(MCGOLRICK_HOTSPOT_ID)
+        print(f"Year total: {total}")
+
+        new = await check_for_new_year_lifers(MCGOLRICK_HOTSPOT_ID)
+        if new:
+            total = get_year_total(MCGOLRICK_HOTSPOT_ID)
+            msg = format_year_lifer_message(new, MCGOLRICK_HOTSPOT_NAME, total)
+            print(msg)
+        else:
+            print("No new year lifers found")
+
+        close_state_db()
+
+    asyncio.run(_main())

--- a/src/cloaca/piper/year_lifers.py
+++ b/src/cloaca/piper/year_lifers.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import os
 import random
+from dataclasses import dataclass
 from zoneinfo import ZoneInfo
 
 import duckdb
@@ -17,9 +18,18 @@ from cloaca.scripts.fetch_yearly_hotspot_data import (
 
 logger = logging.getLogger(__name__)
 
-MCGOLRICK_HOTSPOT_ID = "L2987624"
-MCGOLRICK_HOTSPOT_NAME = "McGolrick Park"
-YEAR_LIFERS_CHANNEL_ID = 1492224353537102025
+
+@dataclass
+class Hotspot:
+    id: str
+    name: str
+    channel_id: int
+
+
+WATCHED_HOTSPOTS = [
+    Hotspot(id="L2987624", name="McGolrick Park", channel_id=1492224353537102025),
+    Hotspot(id="L1814508", name="Franz Sigel Park", channel_id=1492237397700776128),
+]
 
 EASTERN = ZoneInfo("America/New_York")
 
@@ -212,6 +222,8 @@ async def backfill_year_species(hotspot_id: str) -> int:
 
     count = len(earliest_per_species)
     _mark_backfill_complete(hotspot_id, year, count)
+    # Flush WAL so external readers (e.g. SSH) can see the data
+    get_state_db().execute("FORCE CHECKPOINT")
     logger.info(
         "backfill complete for %s/%d: %d species (%d failed days)",
         hotspot_id,
@@ -271,6 +283,8 @@ async def check_for_new_year_lifers(
     new_lifers = list(earliest_new.values())
     for obs in new_lifers:
         _insert_species(hotspot_id, now.year, obs)
+    # Flush WAL so external readers (e.g. SSH) can see the data
+    get_state_db().execute("FORCE CHECKPOINT")
 
     logger.info(
         "found %d new year lifer(s) at %s: %s",
@@ -344,19 +358,21 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
 
     async def _main():
-        count = await backfill_year_species(MCGOLRICK_HOTSPOT_ID)
-        print(f"Backfilled {count} species")
+        for hotspot in WATCHED_HOTSPOTS:
+            print(f"\n--- {hotspot.name} ({hotspot.id}) ---")
+            count = await backfill_year_species(hotspot.id)
+            print(f"Backfilled {count} species")
 
-        total = get_year_total(MCGOLRICK_HOTSPOT_ID)
-        print(f"Year total: {total}")
+            total = get_year_total(hotspot.id)
+            print(f"Year total: {total}")
 
-        new = await check_for_new_year_lifers(MCGOLRICK_HOTSPOT_ID)
-        if new:
-            total = get_year_total(MCGOLRICK_HOTSPOT_ID)
-            msg = format_year_lifer_message(new, MCGOLRICK_HOTSPOT_NAME, total)
-            print(msg)
-        else:
-            print("No new year lifers found")
+            new = await check_for_new_year_lifers(hotspot.id)
+            if new:
+                total = get_year_total(hotspot.id)
+                msg = format_year_lifer_message(new, hotspot.name, total)
+                print(msg)
+            else:
+                print("No new year lifers found")
 
         close_state_db()
 

--- a/src/cloaca/piper/year_lifers.py
+++ b/src/cloaca/piper/year_lifers.py
@@ -57,6 +57,15 @@ def _ensure_tables(con: duckdb.DuckDBPyConnection):
             PRIMARY KEY (hotspot_id, year, species_code)
         );
     """)
+    con.execute("""
+        CREATE TABLE IF NOT EXISTS backfill_status (
+            hotspot_id VARCHAR NOT NULL,
+            year INTEGER NOT NULL,
+            completed_at TIMESTAMP NOT NULL,
+            species_count INTEGER NOT NULL,
+            PRIMARY KEY (hotspot_id, year)
+        );
+    """)
 
 
 def get_year_total(hotspot_id: str) -> int:
@@ -139,17 +148,36 @@ async def fetch_observations_for_date(
 # ---------------------------------------------------------------------------
 
 
+def _is_backfill_complete(hotspot_id: str, year: int) -> bool:
+    row = (
+        get_state_db()
+        .execute(
+            "SELECT 1 FROM backfill_status WHERE hotspot_id = ? AND year = ?",
+            [hotspot_id, year],
+        )
+        .fetchone()
+    )
+    return row is not None
+
+
+def _mark_backfill_complete(hotspot_id: str, year: int, species_count: int):
+    get_state_db().execute(
+        """INSERT INTO backfill_status (hotspot_id, year, completed_at, species_count)
+           VALUES (?, ?, CURRENT_TIMESTAMP, ?)
+           ON CONFLICT DO NOTHING""",
+        [hotspot_id, year, species_count],
+    )
+
+
 async def backfill_year_species(hotspot_id: str) -> int:
     now = datetime.datetime.now(EASTERN)
     year = now.year
 
-    existing = get_year_total(hotspot_id)
-    if existing > 0:
+    if _is_backfill_complete(hotspot_id, year):
         logger.info(
-            "skipping backfill for %s/%d — already have %d species",
+            "skipping backfill for %s/%d — already complete",
             hotspot_id,
             year,
-            existing,
         )
         return 0
 
@@ -183,6 +211,7 @@ async def backfill_year_species(hotspot_id: str) -> int:
         _insert_species(hotspot_id, year, obs)
 
     count = len(earliest_per_species)
+    _mark_backfill_complete(hotspot_id, year, count)
     logger.info(
         "backfill complete for %s/%d: %d species (%d failed days)",
         hotspot_id,
@@ -205,9 +234,14 @@ async def check_for_new_year_lifers(
     today = now.date()
     yesterday = today - datetime.timedelta(days=1)
 
-    # Fetch observations for today and yesterday
+    # Fetch observations for today and yesterday (skip yesterday on Jan 1
+    # to avoid counting last year's observations as new-year lifers)
+    dates_to_check = [today]
+    if yesterday.year == today.year:
+        dates_to_check.append(yesterday)
+
     observations: list[eBirdHistoricFullObservation] = []
-    for date in (today, yesterday):
+    for date in dates_to_check:
         try:
             observations.extend(await fetch_observations_for_date(hotspot_id, date))
         except Exception:

--- a/src/cloaca/piper/year_lifers.py
+++ b/src/cloaca/piper/year_lifers.py
@@ -313,7 +313,7 @@ def format_year_lifer_message(
         header = f"{birds[0]} **Year Bird #{year_total} for {hotspot_name}!**"
         checklist_url = f"https://ebird.org/checklist/{obs.checklistId}"
         body = (
-            f"\U0001f426 **{obs.comName}** — first spotted by "
+            f"**{obs.comName}** — first spotted by "
             f"{obs.userDisplayName} ({date_str})\n"
             f"[View checklist]({checklist_url})"
         )
@@ -329,7 +329,7 @@ def format_year_lifer_message(
         date_str = obs.obsDt.strftime("%b %-d")
         checklist_url = f"https://ebird.org/checklist/{obs.checklistId}"
         lines.append(
-            f"\U0001f426 **{obs.comName}** — {obs.userDisplayName} "
+            f"**{obs.comName}** — {obs.userDisplayName} "
             f"({date_str}) · [checklist]({checklist_url})"
         )
     return "\n".join(lines)


### PR DESCRIPTION
## Summary

- Adds year lifer tracking for watched eBird hotspots — polls every 15 min (hourly at night) for new species seen for the first time that calendar year
- Currently watching **McGolrick Park** and **Franz Sigel Park**, each posting to its own Discord channel
- On first startup per hotspot, backfills the full year from the eBird API day-by-day
- Shows observer name, date, and checklist link in notifications; handles single and multiple new lifers in one update
- Stores state in a separate writable DuckDB file (`PIPER_STATE_DB_PATH`) with `FORCE CHECKPOINT` for SSH readability
- Hotspots are configured via a `WATCHED_HOTSPOTS` list — adding a new park is one line

## New env vars
- `PIPER_STATE_DB_PATH` — path to writable state DB (defaults to `piper_state.db`, set to `/var/data/piper_state.db` on Render)

## Key files
- `src/cloaca/piper/year_lifers.py` — new module (backfill, polling, formatting, state DB)
- `src/cloaca/piper/main.py` — task loop and on_ready integration
- `render.yaml` — added `PIPER_STATE_DB_PATH` env var
- `src/cloaca/piper/CLAUDE.md` — full documentation

## Test plan
- [x] Backfill: McGolrick (44 species) and Franz Sigel (53 species), 0 failed days each
- [x] Notification: American Robin notification posted to #mcgolrick-park (via test)
- [x] Notification: Osprey notification posted to #franz-sigel-park (detected naturally on first poll)
- [x] Night throttling logic reviewed
- [x] Year-boundary edge case fixed (skip yesterday on Jan 1)
- [x] Partial backfill retry via backfill_status table
- [x] Deployed and running on Render from this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)