### PR TITLE
add all-time park lifer tracking to Piper

### DIFF
--- a/src/cloaca/piper/CLAUDE.md
+++ b/src/cloaca/piper/CLAUDE.md
@@ -12,7 +12,7 @@ Piper runs inside the cloaca FastAPI server as an asyncio background task (not a
 - `bird_query.py` — Core query logic. Connects to two MCP servers (eBird API via SSE, DuckDB via stdio), builds a tool-augmented Claude conversation, and streams the response. Contains the system prompt and the cached DuckDB connection pool.
 - `birdcast.py` — Daily BirdCast migration forecast. Fetches a 3-night forecast from the BirdCast API for NYC, formats a color-coded Discord message (🔵 Low, 🟡 Medium, 🔴 High), and posts to #bird-cast-updates. Scheduled via `discord.ext.tasks.loop` at 22:00 UTC (6 PM EDT). Response is validated with Pydantic models (`BirdcastForecast`, `ForecastNight`).
 - `cli.py` — Standalone CLI for testing queries without Discord: `uv run python -m cloaca.piper.cli "what warblers are in prospect park?"`
-- `year_lifers.py` — Year lifer tracking for multiple hotspots. Polls the eBird historic observations API every 15 minutes (hourly at night) to detect new species. Stores the year's species list in a writable DuckDB state DB (`PIPER_STATE_DB_PATH`). On first run, backfills the current year from the API for each hotspot. Posts Discord notifications per hotspot channel when new species are found, including the observer name and checklist link. Hotspots are configured via the `WATCHED_HOTSPOTS` list of `Hotspot` dataclasses. Reuses `eBirdHistoricFullObservation` from `scripts/fetch_yearly_hotspot_data.py` and `get_phoebe_client()` from `api/shared.py`.
+- `year_lifers.py` — Year lifer and all-time park lifer tracking for multiple hotspots. Polls the eBird historic observations API every 15 minutes (hourly at night) to detect new species. Observations are fetched once per hotspot and checked against both the year list and all-time list. Stores state in a writable DuckDB state DB (`PIPER_STATE_DB_PATH`). On first run, backfills the current year day-by-day from the historic API, and backfills all-time species via the `product/spplist` endpoint (single API call per hotspot). Posts Discord notifications per hotspot channel — celebratory 🎉🥳 for all-time lifers, bird emojis for year lifers. If a species is both a year lifer and an all-time lifer, only the all-time notification is posted. Hotspots are configured via the `WATCHED_HOTSPOTS` list of `Hotspot` dataclasses. Reuses `eBirdHistoricFullObservation` from `scripts/fetch_yearly_hotspot_data.py` and `get_phoebe_client()` from `api/shared.py`.
 
 ### How a query flows
 
@@ -45,11 +45,16 @@ The DuckDB MCP server (mcp-server-motherduck) is spawned as a subprocess. To avo
 
 To add a new hotspot, append a `Hotspot` entry to the list.
 
-**State DB**: A separate writable DuckDB file (`PIPER_STATE_DB_PATH`) stores a `hotspot_year_species` table with species code, first observation date, observer name, and checklist ID. This is independent of the large read-only `ebd_nyc.db`. After writes, `FORCE CHECKPOINT` is called so external readers (e.g. SSH sessions) can see the data.
+**State DB**: A separate writable DuckDB file (`PIPER_STATE_DB_PATH`) stores species tracking tables. This is independent of the large read-only `ebd_nyc.db`. Tables:
+- `hotspot_year_species` — year lifer tracking (species code, first observation date, observer name, checklist ID). PK: `(hotspot_id, year, species_code)`.
+- `hotspot_all_time_species` — all-time park species (species code only). PK: `(hotspot_id, species_code)`. Backfilled via the eBird `product/spplist` API.
+- `backfill_status` — tracks backfill completion per hotspot. PK: `(hotspot_id, year)`. Uses `year=0` as sentinel for all-time backfills.
 
-**Backfill**: On first startup per hotspot (tracked in `backfill_status` table), iterates Jan 1 through yesterday calling the eBird API day-by-day (~100 calls per hotspot, 0.5s delay between each). Subsequent startups skip completed hotspots.
+**Year backfill**: On first startup per hotspot (tracked in `backfill_status` table), iterates Jan 1 through yesterday calling the eBird API day-by-day (~100 calls per hotspot, 0.5s delay between each). Subsequent startups skip completed hotspots.
 
-**Polling**: Every 15 minutes, fetches observations for today and yesterday (2 API calls per hotspot). During night hours (10pm–6am ET), enforces at least 1 hour between checks. New species are inserted and posted to the hotspot's Discord channel.
+**All-time backfill**: Single API call to `product/spplist/{hotspot_id}` returns all species codes ever recorded. Tracked in `backfill_status` with `year=0`.
+
+**Polling**: Every 15 minutes, fetches observations for today and yesterday (2 API calls per hotspot). The same observations are checked against both the year list and all-time list — no extra API calls. During night hours (10pm–6am ET), enforces at least 1 hour between checks. New species are inserted and posted to the hotspot's Discord channel. All-time lifers take priority: if a species is both a year lifer and an all-time lifer, only the all-time notification is posted.
 
 **Year rollover**: On Jan 1, the table is empty for the new year, triggering a backfill of 0 days. The regular poll picks up the first species naturally.
 
@@ -58,7 +63,7 @@ To add a new hotspot, append a `Hotspot` entry to the list.
 | Task | Schedule | Channel | Module |
 |------|----------|---------|--------|
 | BirdCast forecast | Daily at 22:00 UTC (6 PM EDT) | #bird-cast-updates | `birdcast.py` |
-| Year lifer check | Every 15 min (hourly at night) | Per hotspot (see `WATCHED_HOTSPOTS`) | `year_lifers.py` |
+| Lifer check (year + all-time) | Every 15 min (hourly at night) | Per hotspot (see `WATCHED_HOTSPOTS`) | `year_lifers.py` |
 
 Both are started in `on_ready()` via `discord.ext.tasks.loop`.
 

--- a/src/cloaca/piper/main.py
+++ b/src/cloaca/piper/main.py
@@ -16,9 +16,15 @@ from cloaca.piper.birdcast import (
 )
 from cloaca.piper.year_lifers import (
     WATCHED_HOTSPOTS,
+    all_time_list_link_view,
+    backfill_all_time_species,
     backfill_year_species,
+    check_for_new_all_time_lifers,
     check_for_new_year_lifers,
+    fetch_recent_observations,
+    format_all_time_lifer_message,
     format_year_lifer_message,
+    get_all_time_total,
     get_year_total,
     year_list_link_view,
 )
@@ -105,26 +111,55 @@ async def check_year_lifers():
         channel = bot.get_channel(hotspot.channel_id)
         if channel is None:
             logger.warning(
-                "could not find year lifers channel %d for %s",
+                "could not find channel %d for %s",
                 hotspot.channel_id,
                 hotspot.name,
             )
             continue
 
         try:
-            new_lifers = await check_for_new_year_lifers(hotspot.id)
+            observations = await fetch_recent_observations(hotspot.id)
+        except Exception:
+            logger.exception("failed to fetch observations for %s", hotspot.name)
+            continue
+
+        # Check all-time lifers first (takes priority over year lifers)
+        try:
+            new_all_time = await check_for_new_all_time_lifers(hotspot.id, observations)
+        except Exception:
+            logger.exception("failed to check all-time lifers for %s", hotspot.name)
+            new_all_time = []
+
+        if new_all_time:
+            total = get_all_time_total(hotspot.id)
+            message = format_all_time_lifer_message(new_all_time, hotspot.name, total)
+            await channel.send(message, view=all_time_list_link_view(hotspot.id))
+            logger.info(
+                "posted %d new all-time lifer(s) for %s",
+                len(new_all_time),
+                hotspot.name,
+            )
+
+        # Check year lifers, excluding any that were all-time lifers
+        try:
+            new_year = await check_for_new_year_lifers(hotspot.id, observations)
         except Exception:
             logger.exception("failed to check year lifers for %s", hotspot.name)
-            continue
+            new_year = []
 
-        if not new_lifers:
-            logger.info("no new year lifers at %s", hotspot.name)
-            continue
+        all_time_codes = {o.speciesCode for o in new_all_time}
+        new_year = [o for o in new_year if o.speciesCode not in all_time_codes]
 
-        total = get_year_total(hotspot.id)
-        message = format_year_lifer_message(new_lifers, hotspot.name, total)
-        await channel.send(message, view=year_list_link_view(hotspot.id))
-        logger.info("posted %d new year lifer(s) for %s", len(new_lifers), hotspot.name)
+        if new_year:
+            total = get_year_total(hotspot.id)
+            message = format_year_lifer_message(new_year, hotspot.name, total)
+            await channel.send(message, view=year_list_link_view(hotspot.id))
+            logger.info(
+                "posted %d new year lifer(s) for %s", len(new_year), hotspot.name
+            )
+
+        if not new_all_time and not new_year:
+            logger.info("no new lifers at %s", hotspot.name)
 
 
 @tasks.loop(time=datetime.time(hour=22, minute=0, tzinfo=datetime.timezone.utc))
@@ -166,6 +201,18 @@ async def on_ready():
                     )
             except Exception:
                 logger.exception("failed to backfill year species for %s", hotspot.name)
+            try:
+                count = await backfill_all_time_species(hotspot.id)
+                if count > 0:
+                    logger.info(
+                        "backfilled %d all-time species for %s",
+                        count,
+                        hotspot.name,
+                    )
+            except Exception:
+                logger.exception(
+                    "failed to backfill all-time species for %s", hotspot.name
+                )
         check_year_lifers.start()
 
 

--- a/src/cloaca/piper/main.py
+++ b/src/cloaca/piper/main.py
@@ -125,7 +125,7 @@ async def check_year_lifers():
 
         # Check all-time lifers first (takes priority over year lifers)
         try:
-            new_all_time = await check_for_new_all_time_lifers(hotspot.id, observations)
+            new_all_time = check_for_new_all_time_lifers(hotspot.id, observations)
         except Exception:
             logger.exception("failed to check all-time lifers for %s", hotspot.name)
             new_all_time = []
@@ -142,7 +142,7 @@ async def check_year_lifers():
 
         # Check year lifers, excluding any that were all-time lifers
         try:
-            new_year = await check_for_new_year_lifers(hotspot.id, observations)
+            new_year = check_for_new_year_lifers(hotspot.id, observations)
         except Exception:
             logger.exception("failed to check year lifers for %s", hotspot.name)
             new_year = []

--- a/src/cloaca/piper/year_lifers.py
+++ b/src/cloaca/piper/year_lifers.py
@@ -76,6 +76,13 @@ def _ensure_tables(con: duckdb.DuckDBPyConnection):
             PRIMARY KEY (hotspot_id, year)
         );
     """)
+    con.execute("""
+        CREATE TABLE IF NOT EXISTS hotspot_all_time_species (
+            hotspot_id VARCHAR NOT NULL,
+            species_code VARCHAR NOT NULL,
+            PRIMARY KEY (hotspot_id, species_code)
+        );
+    """)
 
 
 def get_year_total(hotspot_id: str) -> int:
@@ -101,6 +108,39 @@ def _get_known_species(hotspot_id: str, year: int) -> set[str]:
         .fetchall()
     )
     return {row[0] for row in rows}
+
+
+def get_all_time_total(hotspot_id: str) -> int:
+    rows = (
+        get_state_db()
+        .execute(
+            "SELECT COUNT(*) FROM hotspot_all_time_species WHERE hotspot_id = ?",
+            [hotspot_id],
+        )
+        .fetchone()
+    )
+    return rows[0] if rows else 0
+
+
+def _get_known_all_time_species(hotspot_id: str) -> set[str]:
+    rows = (
+        get_state_db()
+        .execute(
+            "SELECT species_code FROM hotspot_all_time_species WHERE hotspot_id = ?",
+            [hotspot_id],
+        )
+        .fetchall()
+    )
+    return {row[0] for row in rows}
+
+
+def _insert_all_time_species(hotspot_id: str, species_code: str):
+    get_state_db().execute(
+        """INSERT INTO hotspot_all_time_species (hotspot_id, species_code)
+           VALUES (?, ?)
+           ON CONFLICT DO NOTHING""",
+        [hotspot_id, species_code],
+    )
 
 
 def _insert_species(
@@ -222,8 +262,7 @@ async def backfill_year_species(hotspot_id: str) -> int:
 
     count = len(earliest_per_species)
     _mark_backfill_complete(hotspot_id, year, count)
-    # Flush WAL so external readers (e.g. SSH) can see the data
-    get_state_db().execute("FORCE CHECKPOINT")
+
     logger.info(
         "backfill complete for %s/%d: %d species (%d failed days)",
         hotspot_id,
@@ -234,20 +273,43 @@ async def backfill_year_species(hotspot_id: str) -> int:
     return count
 
 
+ALL_TIME_BACKFILL_YEAR = 0
+
+
+async def backfill_all_time_species(hotspot_id: str) -> int:
+    if _is_backfill_complete(hotspot_id, ALL_TIME_BACKFILL_YEAR):
+        logger.info("skipping all-time backfill for %s — already complete", hotspot_id)
+        return 0
+
+    logger.info("starting all-time species backfill for %s", hotspot_id)
+
+    species_codes = await get_phoebe_client().product.species_list.list(
+        region_code=hotspot_id
+    )
+
+    for code in species_codes:
+        _insert_all_time_species(hotspot_id, code)
+
+    count = len(species_codes)
+    _mark_backfill_complete(hotspot_id, ALL_TIME_BACKFILL_YEAR, count)
+    logger.info("all-time backfill complete for %s: %d species", hotspot_id, count)
+    return count
+
+
 # ---------------------------------------------------------------------------
 # Polling
 # ---------------------------------------------------------------------------
 
 
-async def check_for_new_year_lifers(
+async def fetch_recent_observations(
     hotspot_id: str,
 ) -> list[eBirdHistoricFullObservation]:
+    """Fetch observations for today and yesterday (shared by year + all-time checks)."""
     now = datetime.datetime.now(EASTERN)
     today = now.date()
     yesterday = today - datetime.timedelta(days=1)
 
-    # Fetch observations for today and yesterday (skip yesterday on Jan 1
-    # to avoid counting last year's observations as new-year lifers)
+    # Skip yesterday on Jan 1 to avoid counting last year's observations
     dates_to_check = [today]
     if yesterday.year == today.year:
         dates_to_check.append(yesterday)
@@ -261,12 +323,14 @@ async def check_for_new_year_lifers(
                 "failed to fetch observations for %s on %s", hotspot_id, date
             )
 
-    if not observations:
-        return []
+    return observations
 
-    known = _get_known_species(hotspot_id, now.year)
 
-    # Group by species, keep earliest observation per species
+def _find_new_species(
+    observations: list[eBirdHistoricFullObservation],
+    known: set[str],
+) -> list[eBirdHistoricFullObservation]:
+    """From observations, find species not in known set. Returns earliest obs per species."""
     earliest_new: dict[str, eBirdHistoricFullObservation] = {}
     for obs in observations:
         if obs.speciesCode in known:
@@ -275,19 +339,54 @@ async def check_for_new_year_lifers(
             earliest_new[obs.speciesCode] = obs
         elif obs.obsDt < earliest_new[obs.speciesCode].obsDt:
             earliest_new[obs.speciesCode] = obs
+    return list(earliest_new.values())
 
-    if not earliest_new:
+
+async def check_for_new_year_lifers(
+    hotspot_id: str,
+    observations: list[eBirdHistoricFullObservation],
+) -> list[eBirdHistoricFullObservation]:
+    now = datetime.datetime.now(EASTERN)
+
+    if not observations:
         return []
 
-    # Insert new lifers into DB
-    new_lifers = list(earliest_new.values())
+    known = _get_known_species(hotspot_id, now.year)
+    new_lifers = _find_new_species(observations, known)
+
+    if not new_lifers:
+        return []
+
     for obs in new_lifers:
         _insert_species(hotspot_id, now.year, obs)
-    # Flush WAL so external readers (e.g. SSH) can see the data
-    get_state_db().execute("FORCE CHECKPOINT")
 
     logger.info(
         "found %d new year lifer(s) at %s: %s",
+        len(new_lifers),
+        hotspot_id,
+        ", ".join(o.comName for o in new_lifers),
+    )
+    return new_lifers
+
+
+async def check_for_new_all_time_lifers(
+    hotspot_id: str,
+    observations: list[eBirdHistoricFullObservation],
+) -> list[eBirdHistoricFullObservation]:
+    if not observations:
+        return []
+
+    known = _get_known_all_time_species(hotspot_id)
+    new_lifers = _find_new_species(observations, known)
+
+    if not new_lifers:
+        return []
+
+    for obs in new_lifers:
+        _insert_all_time_species(hotspot_id, obs.speciesCode)
+
+    logger.info(
+        "found %d new all-time lifer(s) at %s: %s",
         len(new_lifers),
         hotspot_id,
         ", ".join(o.comName for o in new_lifers),
@@ -335,6 +434,52 @@ def format_year_lifer_message(
     return "\n".join(lines)
 
 
+def format_all_time_lifer_message(
+    new_lifers: list[eBirdHistoricFullObservation],
+    hotspot_name: str,
+    all_time_total: int,
+) -> str:
+    if len(new_lifers) == 1:
+        obs = new_lifers[0]
+        date_str = obs.obsDt.strftime("%b %-d")
+        header = (
+            f"🎉🥳 **New Park Bird for {hotspot_name}!** (#{all_time_total} all-time)"
+        )
+        checklist_url = f"https://ebird.org/checklist/{obs.checklistId}"
+        body = (
+            f"**{obs.comName}** — first spotted by "
+            f"{obs.userDisplayName} ({date_str})\n"
+            f"[View checklist]({checklist_url})"
+        )
+        return f"{header}\n\n{body}"
+
+    header = (
+        f"🎉🥳 **{len(new_lifers)} New Park Birds "
+        f"for {hotspot_name}!** (now at {all_time_total} species all-time)"
+    )
+    lines = [header, ""]
+    for obs in new_lifers:
+        date_str = obs.obsDt.strftime("%b %-d")
+        checklist_url = f"https://ebird.org/checklist/{obs.checklistId}"
+        lines.append(
+            f"**{obs.comName}** — {obs.userDisplayName} "
+            f"({date_str}) · [checklist]({checklist_url})"
+        )
+    return "\n".join(lines)
+
+
+def all_time_list_link_view(hotspot_id: str) -> discord.ui.View:
+    view = discord.ui.View()
+    view.add_item(
+        discord.ui.Button(
+            style=discord.ButtonStyle.link,
+            label="View All-Time List on eBird",
+            url=f"https://ebird.org/hotspot/{hotspot_id}/bird-list",
+        )
+    )
+    return view
+
+
 def year_list_link_view(hotspot_id: str) -> discord.ui.View:
     view = discord.ui.View()
     view.add_item(
@@ -360,16 +505,33 @@ if __name__ == "__main__":
     async def _main():
         for hotspot in WATCHED_HOTSPOTS:
             print(f"\n--- {hotspot.name} ({hotspot.id}) ---")
-            count = await backfill_year_species(hotspot.id)
-            print(f"Backfilled {count} species")
 
-            total = get_year_total(hotspot.id)
-            print(f"Year total: {total}")
+            year_count = await backfill_year_species(hotspot.id)
+            print(f"Backfilled {year_count} year species")
 
-            new = await check_for_new_year_lifers(hotspot.id)
-            if new:
+            all_time_count = await backfill_all_time_species(hotspot.id)
+            print(f"Backfilled {all_time_count} all-time species")
+
+            print(f"Year total: {get_year_total(hotspot.id)}")
+            print(f"All-time total: {get_all_time_total(hotspot.id)}")
+
+            observations = await fetch_recent_observations(hotspot.id)
+
+            new_all_time = await check_for_new_all_time_lifers(hotspot.id, observations)
+            if new_all_time:
+                total = get_all_time_total(hotspot.id)
+                msg = format_all_time_lifer_message(new_all_time, hotspot.name, total)
+                print(msg)
+            else:
+                print("No new all-time lifers found")
+
+            # Filter out all-time lifers from year lifer notifications
+            all_time_codes = {o.speciesCode for o in new_all_time}
+            new_year = await check_for_new_year_lifers(hotspot.id, observations)
+            new_year = [o for o in new_year if o.speciesCode not in all_time_codes]
+            if new_year:
                 total = get_year_total(hotspot.id)
-                msg = format_year_lifer_message(new, hotspot.name, total)
+                msg = format_year_lifer_message(new_year, hotspot.name, total)
                 print(msg)
             else:
                 print("No new year lifers found")

--- a/src/cloaca/piper/year_lifers.py
+++ b/src/cloaca/piper/year_lifers.py
@@ -342,7 +342,7 @@ def _find_new_species(
     return list(earliest_new.values())
 
 
-async def check_for_new_year_lifers(
+def check_for_new_year_lifers(
     hotspot_id: str,
     observations: list[eBirdHistoricFullObservation],
 ) -> list[eBirdHistoricFullObservation]:
@@ -369,7 +369,7 @@ async def check_for_new_year_lifers(
     return new_lifers
 
 
-async def check_for_new_all_time_lifers(
+def check_for_new_all_time_lifers(
     hotspot_id: str,
     observations: list[eBirdHistoricFullObservation],
 ) -> list[eBirdHistoricFullObservation]:
@@ -517,7 +517,7 @@ if __name__ == "__main__":
 
             observations = await fetch_recent_observations(hotspot.id)
 
-            new_all_time = await check_for_new_all_time_lifers(hotspot.id, observations)
+            new_all_time = check_for_new_all_time_lifers(hotspot.id, observations)
             if new_all_time:
                 total = get_all_time_total(hotspot.id)
                 msg = format_all_time_lifer_message(new_all_time, hotspot.name, total)
@@ -527,7 +527,7 @@ if __name__ == "__main__":
 
             # Filter out all-time lifers from year lifer notifications
             all_time_codes = {o.speciesCode for o in new_all_time}
-            new_year = await check_for_new_year_lifers(hotspot.id, observations)
+            new_year = check_for_new_year_lifers(hotspot.id, observations)
             new_year = [o for o in new_year if o.speciesCode not in all_time_codes]
             if new_year:
                 total = get_year_total(hotspot.id)


### PR DESCRIPTION
## Summary
- Track when a species is seen at a hotspot for the first time ever (all-time park lifer), alongside the existing year lifer feature
- Backfills via the eBird `product/spplist` API — single call per hotspot (~130 species each)
- Reuses the same polling API calls: observations fetched once per hotspot, checked against both year and all-time lists
- All-time lifers get a celebratory 🎉🥳 notification; suppresses the year lifer post for the same species
- Removes `FORCE CHECKPOINT` calls (DuckDB doesn't support concurrent readers with a writer anyway)

## Test plan
- [x] `uv run python -m cloaca.piper.year_lifers` — backfills all-time species, runs poll cycle, no false notifications
- [x] Simulated new all-time lifer (deleted amerob from DB) — correctly detected and formatted message
- [x] Year lifer suppression — amerob was not double-posted as a year lifer
- [x] Lint and format pass
- [ ] Deploy to Render and verify backfill runs on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)