### PR TITLE
Change BirdCast migration alert from 10 PM UTC to 7 AM Eastern

### DIFF
--- a/src/cloaca/piper/CLAUDE.md
+++ b/src/cloaca/piper/CLAUDE.md
@@ -10,7 +10,7 @@ Piper runs inside the cloaca FastAPI server as an asyncio background task (not a
 
 - `main.py` — Discord bot event handlers (`on_ready`, `on_message`), conversation cache, reply-chain context builder. Entry point is the `start()` coroutine.
 - `bird_query.py` — Core query logic. Connects to two MCP servers (eBird API via SSE, DuckDB via stdio), builds a tool-augmented Claude conversation, and streams the response. Contains the system prompt and the cached DuckDB connection pool.
-- `birdcast.py` — Daily BirdCast migration forecast. Fetches a 3-night forecast from the BirdCast API for NYC, formats a color-coded Discord message (🔵 Low, 🟡 Medium, 🔴 High), and posts to #bird-cast-updates. Scheduled via `discord.ext.tasks.loop` at 22:00 UTC (6 PM EDT). Response is validated with Pydantic models (`BirdcastForecast`, `ForecastNight`).
+- `birdcast.py` — Daily BirdCast migration forecast. Fetches a 3-night forecast from the BirdCast API for NYC, formats a color-coded Discord message (🔵 Low, 🟡 Medium, 🔴 High), and posts to #bird-cast-updates. Scheduled via `discord.ext.tasks.loop` at 7:00 AM Eastern. Response is validated with Pydantic models (`BirdcastForecast`, `ForecastNight`).
 - `cli.py` — Standalone CLI for testing queries without Discord: `uv run python -m cloaca.piper.cli "what warblers are in prospect park?"`
 - `year_lifers.py` — Year lifer and all-time park lifer tracking for multiple hotspots. Polls the eBird historic observations API every 15 minutes (hourly at night) to detect new species. Observations are fetched once per hotspot and checked against both the year list and all-time list. Stores state in a writable DuckDB state DB (`PIPER_STATE_DB_PATH`). On first run, backfills the current year day-by-day from the historic API, and backfills all-time species via the `product/spplist` endpoint (single API call per hotspot). Posts Discord notifications per hotspot channel — celebratory 🎉🥳 for all-time lifers, bird emojis for year lifers. If a species is both a year lifer and an all-time lifer, only the all-time notification is posted. Hotspots are configured via the `WATCHED_HOTSPOTS` list of `Hotspot` dataclasses. Reuses `eBirdHistoricFullObservation` from `scripts/fetch_yearly_hotspot_data.py` and `get_phoebe_client()` from `api/shared.py`.
 
@@ -62,7 +62,7 @@ To add a new hotspot, append a `Hotspot` entry to the list.
 
 | Task | Schedule | Channel | Module |
 |------|----------|---------|--------|
-| BirdCast forecast | Daily at 22:00 UTC (6 PM EDT) | #bird-cast-updates | `birdcast.py` |
+| BirdCast forecast | Daily at 7:00 AM Eastern | #bird-cast-updates | `birdcast.py` |
 | Lifer check (year + all-time) | Every 15 min (hourly at night) | Per hotspot (see `WATCHED_HOTSPOTS`) | `year_lifers.py` |
 
 Both are started in `on_ready()` via `discord.ext.tasks.loop`.

--- a/src/cloaca/piper/main.py
+++ b/src/cloaca/piper/main.py
@@ -162,7 +162,7 @@ async def check_year_lifers():
             logger.info("no new lifers at %s", hotspot.name)
 
 
-@tasks.loop(time=datetime.time(hour=22, minute=0, tzinfo=datetime.timezone.utc))
+@tasks.loop(time=datetime.time(hour=7, minute=0, tzinfo=_EASTERN))
 async def post_birdcast_forecast():
     channel = bot.get_channel(BIRDCAST_CHANNEL_ID)
     if channel is None:


### PR DESCRIPTION
The migration forecast is more useful in the morning before people
head out birding. Uses the existing _EASTERN (America/New_York)
timezone so the schedule automatically adjusts for DST.

https://claude.ai/code/session_01LGbbYxMDSAy5NeYmUHpHjR