### PR TITLE
Move migration alert to 7 AM and add linting to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,26 +7,43 @@ on:
     branches: [ main ]
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v4
-    
+
+    - name: Run Ruff linter
+      uses: astral-sh/ruff-action@v3
+      with:
+        version: "0.9.6"
+
+    - name: Run Ruff formatter
+      uses: astral-sh/ruff-action@v3
+      with:
+        version: "0.9.6"
+        args: "format --check"
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: '3.12'
-    
+
     - name: Install uv
       uses: astral-sh/setup-uv@v2
       with:
         version: "latest"
-    
+
     - name: Install dependencies
       run: |
         uv sync --dev
-    
+
     - name: Run tests
       run: |
         uv run python -m pytest

--- a/src/cloaca/piper/CLAUDE.md
+++ b/src/cloaca/piper/CLAUDE.md
@@ -10,7 +10,7 @@ Piper runs inside the cloaca FastAPI server as an asyncio background task (not a
 
 - `main.py` — Discord bot event handlers (`on_ready`, `on_message`), conversation cache, reply-chain context builder. Entry point is the `start()` coroutine.
 - `bird_query.py` — Core query logic. Connects to two MCP servers (eBird API via SSE, DuckDB via stdio), builds a tool-augmented Claude conversation, and streams the response. Contains the system prompt and the cached DuckDB connection pool.
-- `birdcast.py` — Daily BirdCast migration forecast. Fetches a 3-night forecast from the BirdCast API for NYC, formats a color-coded Discord message (🔵 Low, 🟡 Medium, 🔴 High), and posts to #bird-cast-updates. Scheduled via `discord.ext.tasks.loop` at 22:00 UTC (6 PM EDT). Response is validated with Pydantic models (`BirdcastForecast`, `ForecastNight`).
+- `birdcast.py` — Daily BirdCast migration forecast. Fetches a 3-night forecast from the BirdCast API for NYC, formats a color-coded Discord message (🔵 Low, 🟡 Medium, 🔴 High), and posts to #bird-cast-updates. Scheduled via `discord.ext.tasks.loop` at 7:00 AM Eastern. Response is validated with Pydantic models (`BirdcastForecast`, `ForecastNight`).
 - `cli.py` — Standalone CLI for testing queries without Discord: `uv run python -m cloaca.piper.cli "what warblers are in prospect park?"`
 - `year_lifers.py` — Year lifer and all-time park lifer tracking for multiple hotspots. Polls the eBird historic observations API every 15 minutes (hourly at night) to detect new species. Observations are fetched once per hotspot and checked against both the year list and all-time list. Stores state in a writable DuckDB state DB (`PIPER_STATE_DB_PATH`). On first run, backfills the current year day-by-day from the historic API, and backfills all-time species via the `product/spplist` endpoint (single API call per hotspot). Posts Discord notifications per hotspot channel — celebratory 🎉🥳 for all-time lifers, bird emojis for year lifers. If a species is both a year lifer and an all-time lifer, only the all-time notification is posted. Hotspots are configured via the `WATCHED_HOTSPOTS` list of `Hotspot` dataclasses. Reuses `eBirdHistoricFullObservation` from `scripts/fetch_yearly_hotspot_data.py` and `get_phoebe_client()` from `api/shared.py`.
 
@@ -62,7 +62,7 @@ To add a new hotspot, append a `Hotspot` entry to the list.
 
 | Task | Schedule | Channel | Module |
 |------|----------|---------|--------|
-| BirdCast forecast | Daily at 22:00 UTC (6 PM EDT) | #bird-cast-updates | `birdcast.py` |
+| BirdCast forecast | Daily at 7:00 AM Eastern | #bird-cast-updates | `birdcast.py` |
 | Lifer check (year + all-time) | Every 15 min (hourly at night) | Per hotspot (see `WATCHED_HOTSPOTS`) | `year_lifers.py` |
 
 Both are started in `on_ready()` via `discord.ext.tasks.loop`.

--- a/src/cloaca/piper/cli.py
+++ b/src/cloaca/piper/cli.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
-from cloaca.piper.bird_query import ask_bird_query
+from cloaca.piper.bird_query import ask_bird_query  # noqa: E402
 
 
 async def main():
@@ -13,7 +13,9 @@ async def main():
     print(f">>> {query}\n")
     response, stats, _ = await ask_bird_query(query)
     print(response)
-    print(f"\n[{stats.elapsed_s:.1f}s · {stats.input_tokens + stats.output_tokens:,} tokens · ${stats.cost_usd:.3f} · {stats.tool_calls} tool calls]")
+    print(
+        f"\n[{stats.elapsed_s:.1f}s · {stats.input_tokens + stats.output_tokens:,} tokens · ${stats.cost_usd:.3f} · {stats.tool_calls} tool calls]"
+    )
 
 
 asyncio.run(main())

--- a/src/cloaca/piper/main.py
+++ b/src/cloaca/piper/main.py
@@ -162,7 +162,7 @@ async def check_year_lifers():
             logger.info("no new lifers at %s", hotspot.name)
 
 
-@tasks.loop(time=datetime.time(hour=22, minute=0, tzinfo=datetime.timezone.utc))
+@tasks.loop(time=datetime.time(hour=7, minute=0, tzinfo=_EASTERN))
 async def post_birdcast_forecast():
     channel = bot.get_channel(BIRDCAST_CHANNEL_ID)
     if channel is None:


### PR DESCRIPTION
## Summary

- **BirdCast migration alert moved to 7 AM Eastern** — changed from 22:00 UTC (6 PM EDT) so the forecast arrives before people head out birding. Uses the existing `_EASTERN` (America/New_York) timezone to automatically handle DST.
- **Added Ruff linting to CI** — new `lint` job in the GitHub Actions workflow runs the Ruff linter and format checker (v0.9.6), matching the existing `.pre-commit-config.yaml`. Runs as a separate job from tests.

## Test plan

- [ ] Verify CI lint job passes on this PR
- [ ] Verify CI test job still passes
- [ ] Confirm BirdCast forecast posts at 7 AM Eastern after deploy

https://claude.ai/code/session_01LGbbYxMDSAy5NeYmUHpHjR