### PR TITLE
Add provisional lifer tracking and review confirmation flow

### DIFF
--- a/src/cloaca/piper/main.py
+++ b/src/cloaca/piper/main.py
@@ -21,8 +21,14 @@ from cloaca.piper.year_lifers import (
     backfill_year_species,
     check_for_new_all_time_lifers,
     check_for_new_year_lifers,
+    check_pending_provisionals,
     fetch_recent_observations,
     format_all_time_lifer_message,
+    format_confirmed_all_time_lifer_message,
+    format_confirmed_year_lifer_message,
+    format_invalidated_lifer_message,
+    format_tentative_all_time_lifer_message,
+    format_tentative_year_lifer_message,
     format_year_lifer_message,
     get_all_time_total,
     get_year_total,
@@ -123,42 +129,138 @@ async def check_year_lifers():
             logger.exception("failed to fetch observations for %s", hotspot.name)
             continue
 
-        # Check all-time lifers first (takes priority over year lifers)
+        # ---- Detect new lifers (confirmed + provisional) ----
+
+        # All-time lifers first (takes priority over year lifers)
         try:
-            new_all_time = check_for_new_all_time_lifers(hotspot.id, observations)
+            confirmed_at, provisional_at = check_for_new_all_time_lifers(
+                hotspot.id, observations
+            )
         except Exception:
             logger.exception("failed to check all-time lifers for %s", hotspot.name)
-            new_all_time = []
+            confirmed_at, provisional_at = [], []
 
-        if new_all_time:
+        if confirmed_at:
             total = get_all_time_total(hotspot.id)
-            message = format_all_time_lifer_message(new_all_time, hotspot.name, total)
-            await channel.send(message, view=all_time_list_link_view(hotspot.id))
+            message = format_all_time_lifer_message(
+                confirmed_at, hotspot.name, total
+            )
+            await channel.send(
+                message, view=all_time_list_link_view(hotspot.id)
+            )
             logger.info(
-                "posted %d new all-time lifer(s) for %s",
-                len(new_all_time),
+                "posted %d confirmed all-time lifer(s) for %s",
+                len(confirmed_at),
                 hotspot.name,
             )
 
-        # Check year lifers, excluding any that were all-time lifers
-        try:
-            new_year = check_for_new_year_lifers(hotspot.id, observations)
-        except Exception:
-            logger.exception("failed to check year lifers for %s", hotspot.name)
-            new_year = []
-
-        all_time_codes = {o.speciesCode for o in new_all_time}
-        new_year = [o for o in new_year if o.speciesCode not in all_time_codes]
-
-        if new_year:
-            total = get_year_total(hotspot.id)
-            message = format_year_lifer_message(new_year, hotspot.name, total)
-            await channel.send(message, view=year_list_link_view(hotspot.id))
+        if provisional_at:
+            message = format_tentative_all_time_lifer_message(
+                provisional_at, hotspot.name
+            )
+            await channel.send(
+                message, view=all_time_list_link_view(hotspot.id)
+            )
             logger.info(
-                "posted %d new year lifer(s) for %s", len(new_year), hotspot.name
+                "posted %d tentative all-time lifer(s) for %s",
+                len(provisional_at),
+                hotspot.name,
             )
 
-        if not new_all_time and not new_year:
+        # Year lifers, excluding any that were all-time lifers
+        try:
+            confirmed_yr, provisional_yr = check_for_new_year_lifers(
+                hotspot.id, observations
+            )
+        except Exception:
+            logger.exception("failed to check year lifers for %s", hotspot.name)
+            confirmed_yr, provisional_yr = [], []
+
+        all_time_codes = {
+            o.speciesCode for o in confirmed_at + provisional_at
+        }
+        confirmed_yr = [
+            o for o in confirmed_yr if o.speciesCode not in all_time_codes
+        ]
+        provisional_yr = [
+            o for o in provisional_yr if o.speciesCode not in all_time_codes
+        ]
+
+        if confirmed_yr:
+            total = get_year_total(hotspot.id)
+            message = format_year_lifer_message(
+                confirmed_yr, hotspot.name, total
+            )
+            await channel.send(
+                message, view=year_list_link_view(hotspot.id)
+            )
+            logger.info(
+                "posted %d confirmed year lifer(s) for %s",
+                len(confirmed_yr),
+                hotspot.name,
+            )
+
+        if provisional_yr:
+            message = format_tentative_year_lifer_message(
+                provisional_yr, hotspot.name
+            )
+            await channel.send(
+                message, view=year_list_link_view(hotspot.id)
+            )
+            logger.info(
+                "posted %d tentative year lifer(s) for %s",
+                len(provisional_yr),
+                hotspot.name,
+            )
+
+        # ---- Check previously-pending provisionals for review updates ----
+
+        try:
+            pend_confirmed, pend_invalidated = await check_pending_provisionals(
+                hotspot.id, observations
+            )
+        except Exception:
+            logger.exception(
+                "failed to check pending provisionals for %s", hotspot.name
+            )
+            pend_confirmed, pend_invalidated = [], []
+
+        if pend_confirmed:
+            at_confirmed = [
+                p for p in pend_confirmed if p.lifer_type == "all_time"
+            ]
+            yr_confirmed = [
+                p for p in pend_confirmed if p.lifer_type == "year"
+            ]
+            if at_confirmed:
+                total = get_all_time_total(hotspot.id)
+                message = format_confirmed_all_time_lifer_message(
+                    at_confirmed, hotspot.name, total
+                )
+                await channel.send(
+                    message, view=all_time_list_link_view(hotspot.id)
+                )
+            if yr_confirmed:
+                total = get_year_total(hotspot.id)
+                message = format_confirmed_year_lifer_message(
+                    yr_confirmed, hotspot.name, total
+                )
+                await channel.send(
+                    message, view=year_list_link_view(hotspot.id)
+                )
+
+        if pend_invalidated:
+            message = format_invalidated_lifer_message(
+                pend_invalidated, hotspot.name
+            )
+            await channel.send(message)
+
+        has_activity = (
+            confirmed_at or provisional_at
+            or confirmed_yr or provisional_yr
+            or pend_confirmed or pend_invalidated
+        )
+        if not has_activity:
             logger.info("no new lifers at %s", hotspot.name)
 
 

--- a/src/cloaca/piper/main.py
+++ b/src/cloaca/piper/main.py
@@ -142,12 +142,8 @@ async def check_year_lifers():
 
         if confirmed_at:
             total = get_all_time_total(hotspot.id)
-            message = format_all_time_lifer_message(
-                confirmed_at, hotspot.name, total
-            )
-            await channel.send(
-                message, view=all_time_list_link_view(hotspot.id)
-            )
+            message = format_all_time_lifer_message(confirmed_at, hotspot.name, total)
+            await channel.send(message, view=all_time_list_link_view(hotspot.id))
             logger.info(
                 "posted %d confirmed all-time lifer(s) for %s",
                 len(confirmed_at),
@@ -158,9 +154,7 @@ async def check_year_lifers():
             message = format_tentative_all_time_lifer_message(
                 provisional_at, hotspot.name
             )
-            await channel.send(
-                message, view=all_time_list_link_view(hotspot.id)
-            )
+            await channel.send(message, view=all_time_list_link_view(hotspot.id))
             logger.info(
                 "posted %d tentative all-time lifer(s) for %s",
                 len(provisional_at),
@@ -176,24 +170,16 @@ async def check_year_lifers():
             logger.exception("failed to check year lifers for %s", hotspot.name)
             confirmed_yr, provisional_yr = [], []
 
-        all_time_codes = {
-            o.speciesCode for o in confirmed_at + provisional_at
-        }
-        confirmed_yr = [
-            o for o in confirmed_yr if o.speciesCode not in all_time_codes
-        ]
+        all_time_codes = {o.speciesCode for o in confirmed_at + provisional_at}
+        confirmed_yr = [o for o in confirmed_yr if o.speciesCode not in all_time_codes]
         provisional_yr = [
             o for o in provisional_yr if o.speciesCode not in all_time_codes
         ]
 
         if confirmed_yr:
             total = get_year_total(hotspot.id)
-            message = format_year_lifer_message(
-                confirmed_yr, hotspot.name, total
-            )
-            await channel.send(
-                message, view=year_list_link_view(hotspot.id)
-            )
+            message = format_year_lifer_message(confirmed_yr, hotspot.name, total)
+            await channel.send(message, view=year_list_link_view(hotspot.id))
             logger.info(
                 "posted %d confirmed year lifer(s) for %s",
                 len(confirmed_yr),
@@ -201,12 +187,8 @@ async def check_year_lifers():
             )
 
         if provisional_yr:
-            message = format_tentative_year_lifer_message(
-                provisional_yr, hotspot.name
-            )
-            await channel.send(
-                message, view=year_list_link_view(hotspot.id)
-            )
+            message = format_tentative_year_lifer_message(provisional_yr, hotspot.name)
+            await channel.send(message, view=year_list_link_view(hotspot.id))
             logger.info(
                 "posted %d tentative year lifer(s) for %s",
                 len(provisional_yr),
@@ -226,39 +208,32 @@ async def check_year_lifers():
             pend_confirmed, pend_invalidated = [], []
 
         if pend_confirmed:
-            at_confirmed = [
-                p for p in pend_confirmed if p.lifer_type == "all_time"
-            ]
-            yr_confirmed = [
-                p for p in pend_confirmed if p.lifer_type == "year"
-            ]
+            at_confirmed = [p for p in pend_confirmed if p.lifer_type == "all_time"]
+            yr_confirmed = [p for p in pend_confirmed if p.lifer_type == "year"]
             if at_confirmed:
                 total = get_all_time_total(hotspot.id)
                 message = format_confirmed_all_time_lifer_message(
                     at_confirmed, hotspot.name, total
                 )
-                await channel.send(
-                    message, view=all_time_list_link_view(hotspot.id)
-                )
+                await channel.send(message, view=all_time_list_link_view(hotspot.id))
             if yr_confirmed:
                 total = get_year_total(hotspot.id)
                 message = format_confirmed_year_lifer_message(
                     yr_confirmed, hotspot.name, total
                 )
-                await channel.send(
-                    message, view=year_list_link_view(hotspot.id)
-                )
+                await channel.send(message, view=year_list_link_view(hotspot.id))
 
         if pend_invalidated:
-            message = format_invalidated_lifer_message(
-                pend_invalidated, hotspot.name
-            )
+            message = format_invalidated_lifer_message(pend_invalidated, hotspot.name)
             await channel.send(message)
 
         has_activity = (
-            confirmed_at or provisional_at
-            or confirmed_yr or provisional_yr
-            or pend_confirmed or pend_invalidated
+            confirmed_at
+            or provisional_at
+            or confirmed_yr
+            or provisional_yr
+            or pend_confirmed
+            or pend_invalidated
         )
         if not has_activity:
             logger.info("no new lifers at %s", hotspot.name)

--- a/src/cloaca/piper/year_lifers.py
+++ b/src/cloaca/piper/year_lifers.py
@@ -220,8 +220,7 @@ def _get_pending_provisionals(hotspot_id: str) -> list[PendingProvisional]:
             species_code=r[1],
             common_name=r[2],
             scientific_name=r[3],
-            obs_date=r[4] if isinstance(r[4], datetime.date) else r[4].date()
-            if isinstance(r[4], datetime.datetime) else r[4],
+            obs_date=r[4].date() if isinstance(r[4], datetime.datetime) else r[4],
             observer_name=r[5],
             checklist_id=r[6],
             lifer_type=r[7],

--- a/src/cloaca/piper/year_lifers.py
+++ b/src/cloaca/piper/year_lifers.py
@@ -257,9 +257,7 @@ def _insert_pending_provisional(
     )
 
 
-def _remove_pending_provisional(
-    hotspot_id: str, species_code: str, lifer_type: str
-):
+def _remove_pending_provisional(hotspot_id: str, species_code: str, lifer_type: str):
     get_state_db().execute(
         """DELETE FROM pending_provisional_lifers
            WHERE hotspot_id = ? AND species_code = ? AND lifer_type = ?""",
@@ -472,9 +470,7 @@ def _split_confirmed_provisional(
     provisional: list[eBirdHistoricFullObservation] = []
     for obs in new_lifers:
         if any(
-            o.obsReviewed
-            for o in all_observations
-            if o.speciesCode == obs.speciesCode
+            o.obsReviewed for o in all_observations if o.speciesCode == obs.speciesCode
         ):
             confirmed.append(obs)
         else:
@@ -502,9 +498,7 @@ def check_for_new_year_lifers(
     for obs in new_lifers:
         _insert_species(hotspot_id, now.year, obs)
 
-    confirmed, provisional = _split_confirmed_provisional(
-        new_lifers, observations
-    )
+    confirmed, provisional = _split_confirmed_provisional(new_lifers, observations)
 
     # Track provisional species for follow-up
     for obs in provisional:
@@ -539,9 +533,7 @@ def check_for_new_all_time_lifers(
     for obs in new_lifers:
         _insert_all_time_species(hotspot_id, obs.speciesCode)
 
-    confirmed, provisional = _split_confirmed_provisional(
-        new_lifers, observations
-    )
+    confirmed, provisional = _split_confirmed_provisional(new_lifers, observations)
 
     # Track provisional species for follow-up
     for obs in provisional:
@@ -617,9 +609,7 @@ async def check_pending_provisionals(
     invalidated: list[PendingProvisional] = []
 
     for p in pending:
-        matching = [
-            o for o in all_observations if o.speciesCode == p.species_code
-        ]
+        matching = [o for o in all_observations if o.speciesCode == p.species_code]
         if not matching:
             # Observation gone — invalidated or transient API issue.
             age = (today - p.obs_date).days
@@ -750,12 +740,11 @@ def format_tentative_year_lifer_message(
             f"**{obs.comName}** — reported by "
             f"{obs.userDisplayName} ({date_str})\n"
             f"[View checklist]({checklist_url})\n"
-            f"-# Awaiting eBird review — we'll celebrate once confirmed!"
+            "-# Awaiting eBird review — we'll celebrate once confirmed!"
         )
 
     lines = [
-        f"👀 **{len(new_lifers)} Possible New Year Birds "
-        f"for {hotspot_name}!**",
+        f"👀 **{len(new_lifers)} Possible New Year Birds for {hotspot_name}!**",
         "",
     ]
     for obs in new_lifers:
@@ -765,9 +754,7 @@ def format_tentative_year_lifer_message(
             f"**{obs.comName}** — {obs.userDisplayName} "
             f"({date_str}) · [checklist]({checklist_url})"
         )
-    lines.append(
-        f"-# Awaiting eBird review — we'll celebrate once confirmed!"
-    )
+    lines.append("-# Awaiting eBird review — we'll celebrate once confirmed!")
     return "\n".join(lines)
 
 
@@ -784,12 +771,11 @@ def format_tentative_all_time_lifer_message(
             f"**{obs.comName}** — reported by "
             f"{obs.userDisplayName} ({date_str})\n"
             f"[View checklist]({checklist_url})\n"
-            f"-# Awaiting eBird review — we'll celebrate once confirmed!"
+            "-# Awaiting eBird review — we'll celebrate once confirmed!"
         )
 
     lines = [
-        f"👀 **{len(new_lifers)} Possible New Park Birds "
-        f"for {hotspot_name}!**",
+        f"👀 **{len(new_lifers)} Possible New Park Birds for {hotspot_name}!**",
         "",
     ]
     for obs in new_lifers:
@@ -799,9 +785,7 @@ def format_tentative_all_time_lifer_message(
             f"**{obs.comName}** — {obs.userDisplayName} "
             f"({date_str}) · [checklist]({checklist_url})"
         )
-    lines.append(
-        f"-# Awaiting eBird review — we'll celebrate once confirmed!"
-    )
+    lines.append("-# Awaiting eBird review — we'll celebrate once confirmed!")
     return "\n".join(lines)
 
 
@@ -832,10 +816,7 @@ def format_confirmed_year_lifer_message(
     lines = [header, ""]
     for p in confirmed:
         checklist_url = f"https://ebird.org/checklist/{p.checklist_id}"
-        lines.append(
-            f"**{p.common_name}** — confirmed! · "
-            f"[checklist]({checklist_url})"
-        )
+        lines.append(f"**{p.common_name}** — confirmed! · [checklist]({checklist_url})")
     return "\n".join(lines)
 
 
@@ -861,10 +842,7 @@ def format_confirmed_all_time_lifer_message(
     lines = [header, ""]
     for p in confirmed:
         checklist_url = f"https://ebird.org/checklist/{p.checklist_id}"
-        lines.append(
-            f"**{p.common_name}** — confirmed! · "
-            f"[checklist]({checklist_url})"
-        )
+        lines.append(f"**{p.common_name}** — confirmed! · [checklist]({checklist_url})")
     return "\n".join(lines)
 
 
@@ -879,8 +857,7 @@ def format_invalidated_lifer_message(
             f"after eBird review."
         )
     return (
-        f"**Update:** {names} at {hotspot_name} were not confirmed "
-        f"after eBird review."
+        f"**Update:** {names} at {hotspot_name} were not confirmed after eBird review."
     )
 
 
@@ -940,19 +917,25 @@ if __name__ == "__main__":
                 total = get_all_time_total(hotspot.id)
                 print(format_all_time_lifer_message(confirmed_at, hotspot.name, total))
             if provisional_at:
-                print(format_tentative_all_time_lifer_message(provisional_at, hotspot.name))
+                print(
+                    format_tentative_all_time_lifer_message(
+                        provisional_at, hotspot.name
+                    )
+                )
             if not confirmed_at and not provisional_at:
                 print("No new all-time lifers found")
 
             # Filter out all-time lifers from year lifer notifications
-            all_time_codes = {
-                o.speciesCode for o in confirmed_at + provisional_at
-            }
+            all_time_codes = {o.speciesCode for o in confirmed_at + provisional_at}
             confirmed_yr, provisional_yr = check_for_new_year_lifers(
                 hotspot.id, observations
             )
-            confirmed_yr = [o for o in confirmed_yr if o.speciesCode not in all_time_codes]
-            provisional_yr = [o for o in provisional_yr if o.speciesCode not in all_time_codes]
+            confirmed_yr = [
+                o for o in confirmed_yr if o.speciesCode not in all_time_codes
+            ]
+            provisional_yr = [
+                o for o in provisional_yr if o.speciesCode not in all_time_codes
+            ]
             if confirmed_yr:
                 total = get_year_total(hotspot.id)
                 print(format_year_lifer_message(confirmed_yr, hotspot.name, total))
@@ -966,14 +949,26 @@ if __name__ == "__main__":
                 hotspot.id, observations
             )
             if confirmed_pending:
-                year_confirmed = [p for p in confirmed_pending if p.lifer_type == "year"]
-                at_confirmed = [p for p in confirmed_pending if p.lifer_type == "all_time"]
+                year_confirmed = [
+                    p for p in confirmed_pending if p.lifer_type == "year"
+                ]
+                at_confirmed = [
+                    p for p in confirmed_pending if p.lifer_type == "all_time"
+                ]
                 if at_confirmed:
                     total = get_all_time_total(hotspot.id)
-                    print(format_confirmed_all_time_lifer_message(at_confirmed, hotspot.name, total))
+                    print(
+                        format_confirmed_all_time_lifer_message(
+                            at_confirmed, hotspot.name, total
+                        )
+                    )
                 if year_confirmed:
                     total = get_year_total(hotspot.id)
-                    print(format_confirmed_year_lifer_message(year_confirmed, hotspot.name, total))
+                    print(
+                        format_confirmed_year_lifer_message(
+                            year_confirmed, hotspot.name, total
+                        )
+                    )
             if invalidated:
                 print(format_invalidated_lifer_message(invalidated, hotspot.name))
 

--- a/src/cloaca/piper/year_lifers.py
+++ b/src/cloaca/piper/year_lifers.py
@@ -184,6 +184,7 @@ async def fetch_observations_for_date(
         cat="species",
         r=[hotspot_id],
         detail="full",
+        include_provisional=True,
     )
     text = await raw_response.text()
     if not text or text.strip() == "[]":

--- a/src/cloaca/piper/year_lifers.py
+++ b/src/cloaca/piper/year_lifers.py
@@ -26,6 +26,20 @@ class Hotspot:
     channel_id: int
 
 
+@dataclass
+class PendingProvisional:
+    hotspot_id: str
+    species_code: str
+    common_name: str
+    scientific_name: str
+    obs_date: datetime.date
+    observer_name: str
+    checklist_id: str
+    lifer_type: str  # 'year' or 'all_time'
+    year: int | None  # set for year lifers
+    created_at: datetime.datetime | None = None
+
+
 WATCHED_HOTSPOTS = [
     Hotspot(id="L2987624", name="McGolrick Park", channel_id=1492224353537102025),
     Hotspot(id="L1814508", name="Franz Sigel Park", channel_id=1492237397700776128),
@@ -81,6 +95,21 @@ def _ensure_tables(con: duckdb.DuckDBPyConnection):
             hotspot_id VARCHAR NOT NULL,
             species_code VARCHAR NOT NULL,
             PRIMARY KEY (hotspot_id, species_code)
+        );
+    """)
+    con.execute("""
+        CREATE TABLE IF NOT EXISTS pending_provisional_lifers (
+            hotspot_id VARCHAR NOT NULL,
+            species_code VARCHAR NOT NULL,
+            common_name VARCHAR NOT NULL,
+            scientific_name VARCHAR NOT NULL,
+            obs_date DATE NOT NULL,
+            observer_name VARCHAR NOT NULL,
+            checklist_id VARCHAR NOT NULL,
+            lifer_type VARCHAR NOT NULL,
+            year INTEGER,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (hotspot_id, species_code, lifer_type)
         );
     """)
 
@@ -164,6 +193,94 @@ def _insert_species(
             obs.userDisplayName,
             obs.checklistId,
         ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pending provisional helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_pending_provisionals(hotspot_id: str) -> list[PendingProvisional]:
+    rows = (
+        get_state_db()
+        .execute(
+            """SELECT hotspot_id, species_code, common_name, scientific_name,
+                      obs_date, observer_name, checklist_id, lifer_type, year,
+                      created_at
+               FROM pending_provisional_lifers
+               WHERE hotspot_id = ?""",
+            [hotspot_id],
+        )
+        .fetchall()
+    )
+    return [
+        PendingProvisional(
+            hotspot_id=r[0],
+            species_code=r[1],
+            common_name=r[2],
+            scientific_name=r[3],
+            obs_date=r[4] if isinstance(r[4], datetime.date) else r[4].date()
+            if isinstance(r[4], datetime.datetime) else r[4],
+            observer_name=r[5],
+            checklist_id=r[6],
+            lifer_type=r[7],
+            year=r[8],
+            created_at=r[9],
+        )
+        for r in rows
+    ]
+
+
+def _insert_pending_provisional(
+    hotspot_id: str,
+    obs: eBirdHistoricFullObservation,
+    lifer_type: str,
+    year: int | None = None,
+):
+    get_state_db().execute(
+        """INSERT INTO pending_provisional_lifers
+           (hotspot_id, species_code, common_name, scientific_name,
+            obs_date, observer_name, checklist_id, lifer_type, year)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT DO NOTHING""",
+        [
+            hotspot_id,
+            obs.speciesCode,
+            obs.comName,
+            obs.sciName,
+            obs.obsDt.date(),
+            obs.userDisplayName,
+            obs.checklistId,
+            lifer_type,
+            year,
+        ],
+    )
+
+
+def _remove_pending_provisional(
+    hotspot_id: str, species_code: str, lifer_type: str
+):
+    get_state_db().execute(
+        """DELETE FROM pending_provisional_lifers
+           WHERE hotspot_id = ? AND species_code = ? AND lifer_type = ?""",
+        [hotspot_id, species_code, lifer_type],
+    )
+
+
+def _remove_year_species(hotspot_id: str, year: int, species_code: str):
+    get_state_db().execute(
+        """DELETE FROM hotspot_year_species
+           WHERE hotspot_id = ? AND year = ? AND species_code = ?""",
+        [hotspot_id, year, species_code],
+    )
+
+
+def _remove_all_time_species(hotspot_id: str, species_code: str):
+    get_state_db().execute(
+        """DELETE FROM hotspot_all_time_species
+           WHERE hotspot_id = ? AND species_code = ?""",
+        [hotspot_id, species_code],
     )
 
 
@@ -343,56 +460,205 @@ def _find_new_species(
     return list(earliest_new.values())
 
 
+def _split_confirmed_provisional(
+    new_lifers: list[eBirdHistoricFullObservation],
+    all_observations: list[eBirdHistoricFullObservation],
+) -> tuple[list[eBirdHistoricFullObservation], list[eBirdHistoricFullObservation]]:
+    """Split new lifers into confirmed (reviewed) and provisional (unreviewed).
+
+    A species is confirmed if ANY observation of it is reviewed (not just the
+    earliest one returned by _find_new_species).
+    """
+    confirmed: list[eBirdHistoricFullObservation] = []
+    provisional: list[eBirdHistoricFullObservation] = []
+    for obs in new_lifers:
+        if any(
+            o.obsReviewed
+            for o in all_observations
+            if o.speciesCode == obs.speciesCode
+        ):
+            confirmed.append(obs)
+        else:
+            provisional.append(obs)
+    return confirmed, provisional
+
+
 def check_for_new_year_lifers(
     hotspot_id: str,
     observations: list[eBirdHistoricFullObservation],
-) -> list[eBirdHistoricFullObservation]:
+) -> tuple[list[eBirdHistoricFullObservation], list[eBirdHistoricFullObservation]]:
+    """Returns (confirmed, provisional) new year lifers."""
     now = datetime.datetime.now(EASTERN)
 
     if not observations:
-        return []
+        return [], []
 
     known = _get_known_species(hotspot_id, now.year)
     new_lifers = _find_new_species(observations, known)
 
     if not new_lifers:
-        return []
+        return [], []
 
+    # Insert all into known set (prevents re-alerting on next poll)
     for obs in new_lifers:
         _insert_species(hotspot_id, now.year, obs)
 
+    confirmed, provisional = _split_confirmed_provisional(
+        new_lifers, observations
+    )
+
+    # Track provisional species for follow-up
+    for obs in provisional:
+        _insert_pending_provisional(hotspot_id, obs, "year", now.year)
+
     logger.info(
-        "found %d new year lifer(s) at %s: %s",
+        "found %d new year lifer(s) at %s (%d confirmed, %d provisional): %s",
         len(new_lifers),
         hotspot_id,
+        len(confirmed),
+        len(provisional),
         ", ".join(o.comName for o in new_lifers),
     )
-    return new_lifers
+    return confirmed, provisional
 
 
 def check_for_new_all_time_lifers(
     hotspot_id: str,
     observations: list[eBirdHistoricFullObservation],
-) -> list[eBirdHistoricFullObservation]:
+) -> tuple[list[eBirdHistoricFullObservation], list[eBirdHistoricFullObservation]]:
+    """Returns (confirmed, provisional) new all-time lifers."""
     if not observations:
-        return []
+        return [], []
 
     known = _get_known_all_time_species(hotspot_id)
     new_lifers = _find_new_species(observations, known)
 
     if not new_lifers:
-        return []
+        return [], []
 
+    # Insert all into known set (prevents re-alerting on next poll)
     for obs in new_lifers:
         _insert_all_time_species(hotspot_id, obs.speciesCode)
 
+    confirmed, provisional = _split_confirmed_provisional(
+        new_lifers, observations
+    )
+
+    # Track provisional species for follow-up
+    for obs in provisional:
+        _insert_pending_provisional(hotspot_id, obs, "all_time")
+
     logger.info(
-        "found %d new all-time lifer(s) at %s: %s",
+        "found %d new all-time lifer(s) at %s (%d confirmed, %d provisional): %s",
         len(new_lifers),
         hotspot_id,
+        len(confirmed),
+        len(provisional),
         ", ".join(o.comName for o in new_lifers),
     )
-    return new_lifers
+    return confirmed, provisional
+
+
+# ---------------------------------------------------------------------------
+# Pending provisional review checks
+# ---------------------------------------------------------------------------
+
+# If a provisional observation disappears from the API for this many days,
+# we assume it was invalidated (the observer deleted the checklist or the
+# reviewer rejected the record).
+_PROVISIONAL_STALE_DAYS = 14
+
+
+async def check_pending_provisionals(
+    hotspot_id: str,
+    recent_observations: list[eBirdHistoricFullObservation],
+) -> tuple[list[PendingProvisional], list[PendingProvisional]]:
+    """Re-check pending provisional observations for review-status changes.
+
+    *recent_observations* should already contain today + yesterday (the normal
+    poll data).  For any pending provisional whose obs_date falls outside that
+    window we issue an extra API call so we can see its current review status.
+
+    Returns ``(confirmed, invalidated)`` lists.
+
+    Confirmed = a reviewed observation of the species now exists (eBird only
+    returns ``obsValid=True`` records, so presence + ``obsReviewed`` is enough).
+
+    Invalidated = the observation has vanished from the API for longer than
+    ``_PROVISIONAL_STALE_DAYS``, meaning the reviewer rejected it or the
+    checklist was deleted.
+    """
+    pending = _get_pending_provisionals(hotspot_id)
+    if not pending:
+        return [], []
+
+    now = datetime.datetime.now(EASTERN)
+    today = now.date()
+    yesterday = today - datetime.timedelta(days=1)
+    covered_dates = {today, yesterday}
+
+    # Collect extra dates we need to fetch
+    extra_dates = {p.obs_date for p in pending} - covered_dates
+    extra_observations: list[eBirdHistoricFullObservation] = []
+    for date in extra_dates:
+        try:
+            extra_observations.extend(
+                await fetch_observations_for_date(hotspot_id, date)
+            )
+        except Exception:
+            logger.exception(
+                "failed to fetch observations for pending check %s on %s",
+                hotspot_id,
+                date,
+            )
+
+    all_observations = list(recent_observations) + extra_observations
+
+    confirmed: list[PendingProvisional] = []
+    invalidated: list[PendingProvisional] = []
+
+    for p in pending:
+        matching = [
+            o for o in all_observations if o.speciesCode == p.species_code
+        ]
+        if not matching:
+            # Observation gone — invalidated or transient API issue.
+            age = (today - p.obs_date).days
+            if age >= _PROVISIONAL_STALE_DAYS:
+                invalidated.append(p)
+            continue
+
+        if any(o.obsReviewed for o in matching):
+            # Reviewed observations in the API are always valid (invalid ones
+            # are removed entirely), so this means confirmed.
+            confirmed.append(p)
+
+    # Apply DB changes
+    for p in confirmed:
+        _remove_pending_provisional(p.hotspot_id, p.species_code, p.lifer_type)
+        logger.info(
+            "pending provisional confirmed: %s at %s (%s)",
+            p.common_name,
+            p.hotspot_id,
+            p.lifer_type,
+        )
+
+    for p in invalidated:
+        _remove_pending_provisional(p.hotspot_id, p.species_code, p.lifer_type)
+        # Remove from known species so a future valid observation can trigger
+        # a fresh alert.
+        if p.lifer_type == "year" and p.year is not None:
+            _remove_year_species(p.hotspot_id, p.year, p.species_code)
+        elif p.lifer_type == "all_time":
+            _remove_all_time_species(p.hotspot_id, p.species_code)
+        logger.info(
+            "pending provisional invalidated: %s at %s (%s)",
+            p.common_name,
+            p.hotspot_id,
+            p.lifer_type,
+        )
+
+    return confirmed, invalidated
 
 
 # ---------------------------------------------------------------------------
@@ -469,6 +735,156 @@ def format_all_time_lifer_message(
     return "\n".join(lines)
 
 
+# --- Tentative (unreviewed) alerts ---
+
+
+def format_tentative_year_lifer_message(
+    new_lifers: list[eBirdHistoricFullObservation],
+    hotspot_name: str,
+) -> str:
+    if len(new_lifers) == 1:
+        obs = new_lifers[0]
+        date_str = obs.obsDt.strftime("%b %-d")
+        checklist_url = f"https://ebird.org/checklist/{obs.checklistId}"
+        return (
+            f"👀 **Possible Year Bird for {hotspot_name}!**\n\n"
+            f"**{obs.comName}** — reported by "
+            f"{obs.userDisplayName} ({date_str})\n"
+            f"[View checklist]({checklist_url})\n"
+            f"-# Awaiting eBird review — we'll celebrate once confirmed!"
+        )
+
+    lines = [
+        f"👀 **{len(new_lifers)} Possible New Year Birds "
+        f"for {hotspot_name}!**",
+        "",
+    ]
+    for obs in new_lifers:
+        date_str = obs.obsDt.strftime("%b %-d")
+        checklist_url = f"https://ebird.org/checklist/{obs.checklistId}"
+        lines.append(
+            f"**{obs.comName}** — {obs.userDisplayName} "
+            f"({date_str}) · [checklist]({checklist_url})"
+        )
+    lines.append(
+        f"-# Awaiting eBird review — we'll celebrate once confirmed!"
+    )
+    return "\n".join(lines)
+
+
+def format_tentative_all_time_lifer_message(
+    new_lifers: list[eBirdHistoricFullObservation],
+    hotspot_name: str,
+) -> str:
+    if len(new_lifers) == 1:
+        obs = new_lifers[0]
+        date_str = obs.obsDt.strftime("%b %-d")
+        checklist_url = f"https://ebird.org/checklist/{obs.checklistId}"
+        return (
+            f"👀 **Possible New Park Bird for {hotspot_name}!**\n\n"
+            f"**{obs.comName}** — reported by "
+            f"{obs.userDisplayName} ({date_str})\n"
+            f"[View checklist]({checklist_url})\n"
+            f"-# Awaiting eBird review — we'll celebrate once confirmed!"
+        )
+
+    lines = [
+        f"👀 **{len(new_lifers)} Possible New Park Birds "
+        f"for {hotspot_name}!**",
+        "",
+    ]
+    for obs in new_lifers:
+        date_str = obs.obsDt.strftime("%b %-d")
+        checklist_url = f"https://ebird.org/checklist/{obs.checklistId}"
+        lines.append(
+            f"**{obs.comName}** — {obs.userDisplayName} "
+            f"({date_str}) · [checklist]({checklist_url})"
+        )
+    lines.append(
+        f"-# Awaiting eBird review — we'll celebrate once confirmed!"
+    )
+    return "\n".join(lines)
+
+
+# --- Confirmed (after review) alerts ---
+
+
+def format_confirmed_year_lifer_message(
+    confirmed: list[PendingProvisional],
+    hotspot_name: str,
+    year_total: int,
+) -> str:
+    birds = random.sample(BIRD_EMOJIS, min(2, len(BIRD_EMOJIS)))
+
+    if len(confirmed) == 1:
+        p = confirmed[0]
+        checklist_url = f"https://ebird.org/checklist/{p.checklist_id}"
+        return (
+            f"{birds[0]} **Confirmed! Year Bird #{year_total} "
+            f"for {hotspot_name}!**\n\n"
+            f"**{p.common_name}** has been reviewed and confirmed on eBird!\n"
+            f"[View checklist]({checklist_url})"
+        )
+
+    header = (
+        f"{birds[0]}{birds[1]} **{len(confirmed)} Year Birds Confirmed "
+        f"for {hotspot_name}!** (now at {year_total} species)"
+    )
+    lines = [header, ""]
+    for p in confirmed:
+        checklist_url = f"https://ebird.org/checklist/{p.checklist_id}"
+        lines.append(
+            f"**{p.common_name}** — confirmed! · "
+            f"[checklist]({checklist_url})"
+        )
+    return "\n".join(lines)
+
+
+def format_confirmed_all_time_lifer_message(
+    confirmed: list[PendingProvisional],
+    hotspot_name: str,
+    all_time_total: int,
+) -> str:
+    if len(confirmed) == 1:
+        p = confirmed[0]
+        checklist_url = f"https://ebird.org/checklist/{p.checklist_id}"
+        return (
+            f"🎉🥳 **Confirmed! New Park Bird for {hotspot_name}!** "
+            f"(#{all_time_total} all-time)\n\n"
+            f"**{p.common_name}** has been reviewed and confirmed on eBird!\n"
+            f"[View checklist]({checklist_url})"
+        )
+
+    header = (
+        f"🎉🥳 **{len(confirmed)} New Park Birds Confirmed "
+        f"for {hotspot_name}!** (now at {all_time_total} species all-time)"
+    )
+    lines = [header, ""]
+    for p in confirmed:
+        checklist_url = f"https://ebird.org/checklist/{p.checklist_id}"
+        lines.append(
+            f"**{p.common_name}** — confirmed! · "
+            f"[checklist]({checklist_url})"
+        )
+    return "\n".join(lines)
+
+
+def format_invalidated_lifer_message(
+    invalidated: list[PendingProvisional],
+    hotspot_name: str,
+) -> str:
+    names = ", ".join(f"**{p.common_name}**" for p in invalidated)
+    if len(invalidated) == 1:
+        return (
+            f"**Update:** {names} at {hotspot_name} was not confirmed "
+            f"after eBird review."
+        )
+    return (
+        f"**Update:** {names} at {hotspot_name} were not confirmed "
+        f"after eBird review."
+    )
+
+
 def all_time_list_link_view(hotspot_id: str) -> discord.ui.View:
     view = discord.ui.View()
     view.add_item(
@@ -518,24 +934,49 @@ if __name__ == "__main__":
 
             observations = await fetch_recent_observations(hotspot.id)
 
-            new_all_time = check_for_new_all_time_lifers(hotspot.id, observations)
-            if new_all_time:
+            confirmed_at, provisional_at = check_for_new_all_time_lifers(
+                hotspot.id, observations
+            )
+            if confirmed_at:
                 total = get_all_time_total(hotspot.id)
-                msg = format_all_time_lifer_message(new_all_time, hotspot.name, total)
-                print(msg)
-            else:
+                print(format_all_time_lifer_message(confirmed_at, hotspot.name, total))
+            if provisional_at:
+                print(format_tentative_all_time_lifer_message(provisional_at, hotspot.name))
+            if not confirmed_at and not provisional_at:
                 print("No new all-time lifers found")
 
             # Filter out all-time lifers from year lifer notifications
-            all_time_codes = {o.speciesCode for o in new_all_time}
-            new_year = check_for_new_year_lifers(hotspot.id, observations)
-            new_year = [o for o in new_year if o.speciesCode not in all_time_codes]
-            if new_year:
+            all_time_codes = {
+                o.speciesCode for o in confirmed_at + provisional_at
+            }
+            confirmed_yr, provisional_yr = check_for_new_year_lifers(
+                hotspot.id, observations
+            )
+            confirmed_yr = [o for o in confirmed_yr if o.speciesCode not in all_time_codes]
+            provisional_yr = [o for o in provisional_yr if o.speciesCode not in all_time_codes]
+            if confirmed_yr:
                 total = get_year_total(hotspot.id)
-                msg = format_year_lifer_message(new_year, hotspot.name, total)
-                print(msg)
-            else:
+                print(format_year_lifer_message(confirmed_yr, hotspot.name, total))
+            if provisional_yr:
+                print(format_tentative_year_lifer_message(provisional_yr, hotspot.name))
+            if not confirmed_yr and not provisional_yr:
                 print("No new year lifers found")
+
+            # Check pending provisionals
+            confirmed_pending, invalidated = await check_pending_provisionals(
+                hotspot.id, observations
+            )
+            if confirmed_pending:
+                year_confirmed = [p for p in confirmed_pending if p.lifer_type == "year"]
+                at_confirmed = [p for p in confirmed_pending if p.lifer_type == "all_time"]
+                if at_confirmed:
+                    total = get_all_time_total(hotspot.id)
+                    print(format_confirmed_all_time_lifer_message(at_confirmed, hotspot.name, total))
+                if year_confirmed:
+                    total = get_year_total(hotspot.id)
+                    print(format_confirmed_year_lifer_message(year_confirmed, hotspot.name, total))
+            if invalidated:
+                print(format_invalidated_lifer_message(invalidated, hotspot.name))
 
         close_state_db()
 

--- a/tests/piper/conftest.py
+++ b/tests/piper/conftest.py
@@ -1,0 +1,5 @@
+import os
+
+# Set a dummy eBird API key so the phoebe client can be imported.
+# All actual API calls are mocked in tests.
+os.environ.setdefault("EBIRD_API_KEY", "test-dummy-key")

--- a/tests/piper/test_main.py
+++ b/tests/piper/test_main.py
@@ -1,0 +1,332 @@
+"""Tests for the check_year_lifers orchestration in piper/main.py.
+
+All year_lifers functions are mocked so we test only the wiring:
+which messages get sent to which channels, and how confirmed vs.
+provisional vs. pending results are handled.
+"""
+
+import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cloaca.piper.year_lifers import PendingProvisional
+from cloaca.scripts.fetch_yearly_hotspot_data import eBirdHistoricFullObservation
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+HOTSPOT_ID = "L1814508"
+CHANNEL_ID = 1492237397700776128
+
+
+def make_obs(
+    species_code: str = "yetwar",
+    com_name: str = "Yellow-throated Warbler",
+    obs_reviewed: bool = False,
+    checklist_id: str = "S100001",
+) -> eBirdHistoricFullObservation:
+    return eBirdHistoricFullObservation(
+        speciesCode=species_code,
+        comName=com_name,
+        sciName="Setophaga dominica",
+        locId=HOTSPOT_ID,
+        locName="Franz Sigel Park",
+        obsDt=datetime.datetime(2026, 4, 11, 8, 30),
+        lat=40.83,
+        lng=-73.92,
+        obsValid=True,
+        obsReviewed=obs_reviewed,
+        locationPrivate=False,
+        subId="S100001",
+        subnational2Code="US-NY-005",
+        subnational2Name="Bronx",
+        subnational1Code="US-NY",
+        subnational1Name="New York",
+        countryCode="US",
+        countryName="United States",
+        userDisplayName="Jane Doe",
+        obsId="OBS1",
+        checklistId=checklist_id,
+        presenceNoted=False,
+        hasComments=False,
+        firstName="Jane",
+        lastName="Doe",
+        hasRichMedia=False,
+    )
+
+
+def make_pending(
+    species_code: str = "yetwar",
+    common_name: str = "Yellow-throated Warbler",
+    lifer_type: str = "year",
+) -> PendingProvisional:
+    return PendingProvisional(
+        hotspot_id=HOTSPOT_ID,
+        species_code=species_code,
+        common_name=common_name,
+        scientific_name="Setophaga dominica",
+        obs_date=datetime.date(2026, 4, 11),
+        observer_name="Jane Doe",
+        checklist_id="S100001",
+        lifer_type=lifer_type,
+        year=2026 if lifer_type == "year" else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixture: patch all external dependencies on cloaca.piper.main
+# ---------------------------------------------------------------------------
+
+MODULE = "cloaca.piper.main"
+
+
+@pytest.fixture
+def mock_channel():
+    ch = AsyncMock()
+    ch.send = AsyncMock()
+    return ch
+
+
+@pytest.fixture
+def patches(mock_channel):
+    """Patch everything the check_year_lifers loop touches and return the
+    mocks as a dict for easy assertion."""
+    mocks = {}
+
+    p = patch.multiple(
+        MODULE,
+        fetch_recent_observations=AsyncMock(return_value=[]),
+        check_for_new_all_time_lifers=MagicMock(return_value=([], [])),
+        check_for_new_year_lifers=MagicMock(return_value=([], [])),
+        check_pending_provisionals=AsyncMock(return_value=([], [])),
+        get_all_time_total=MagicMock(return_value=100),
+        get_year_total=MagicMock(return_value=42),
+        format_all_time_lifer_message=MagicMock(return_value="AT_MSG"),
+        format_year_lifer_message=MagicMock(return_value="YR_MSG"),
+        format_tentative_all_time_lifer_message=MagicMock(
+            return_value="TENT_AT_MSG"
+        ),
+        format_tentative_year_lifer_message=MagicMock(
+            return_value="TENT_YR_MSG"
+        ),
+        format_confirmed_all_time_lifer_message=MagicMock(
+            return_value="CONF_AT_MSG"
+        ),
+        format_confirmed_year_lifer_message=MagicMock(
+            return_value="CONF_YR_MSG"
+        ),
+        format_invalidated_lifer_message=MagicMock(return_value="INVAL_MSG"),
+        all_time_list_link_view=MagicMock(return_value=None),
+        year_list_link_view=MagicMock(return_value=None),
+    )
+    with p as patched:
+        mocks.update(patched)
+
+    # We also need to patch bot.get_channel
+    bot_patch = patch(f"{MODULE}.bot")
+    with bot_patch as mock_bot:
+        mock_bot.get_channel = MagicMock(return_value=mock_channel)
+        mocks["bot"] = mock_bot
+
+    # We need the _last_year_lifer_check to be set so night check doesn't skip
+    lylc_patch = patch(f"{MODULE}._last_year_lifer_check", None)
+    with lylc_patch:
+        pass
+
+    return mocks
+
+
+async def _run_check(mock_channel, **overrides):
+    """Run check_year_lifers.coro() with all dependencies mocked."""
+    default_mocks = dict(
+        fetch_recent_observations=AsyncMock(return_value=[make_obs()]),
+        check_for_new_all_time_lifers=MagicMock(return_value=([], [])),
+        check_for_new_year_lifers=MagicMock(return_value=([], [])),
+        check_pending_provisionals=AsyncMock(return_value=([], [])),
+        get_all_time_total=MagicMock(return_value=100),
+        get_year_total=MagicMock(return_value=42),
+        format_all_time_lifer_message=MagicMock(return_value="AT_MSG"),
+        format_year_lifer_message=MagicMock(return_value="YR_MSG"),
+        format_tentative_all_time_lifer_message=MagicMock(
+            return_value="TENT_AT_MSG"
+        ),
+        format_tentative_year_lifer_message=MagicMock(
+            return_value="TENT_YR_MSG"
+        ),
+        format_confirmed_all_time_lifer_message=MagicMock(
+            return_value="CONF_AT_MSG"
+        ),
+        format_confirmed_year_lifer_message=MagicMock(
+            return_value="CONF_YR_MSG"
+        ),
+        format_invalidated_lifer_message=MagicMock(return_value="INVAL_MSG"),
+        all_time_list_link_view=MagicMock(return_value=None),
+        year_list_link_view=MagicMock(return_value=None),
+    )
+    default_mocks.update(overrides)
+
+    mock_bot = MagicMock()
+    mock_bot.get_channel = MagicMock(return_value=mock_channel)
+
+    with patch.multiple(MODULE, **default_mocks), \
+         patch(f"{MODULE}.bot", mock_bot), \
+         patch(f"{MODULE}._last_year_lifer_check", None):
+        from cloaca.piper.main import check_year_lifers
+        await check_year_lifers.coro()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckYearLifersConfirmedAlerts:
+    @pytest.mark.asyncio
+    async def test_confirmed_all_time_lifer_sends_full_alert(
+        self, mock_channel
+    ):
+        obs = make_obs(obs_reviewed=True)
+        await _run_check(
+            mock_channel,
+            check_for_new_all_time_lifers=MagicMock(
+                return_value=([obs], [])
+            ),
+        )
+        messages = [
+            call.args[0] for call in mock_channel.send.call_args_list
+        ]
+        assert "AT_MSG" in messages
+
+    @pytest.mark.asyncio
+    async def test_confirmed_year_lifer_sends_full_alert(self, mock_channel):
+        obs = make_obs("amrob", "American Robin", obs_reviewed=True)
+        await _run_check(
+            mock_channel,
+            check_for_new_year_lifers=MagicMock(return_value=([obs], [])),
+        )
+        messages = [
+            call.args[0] for call in mock_channel.send.call_args_list
+        ]
+        assert "YR_MSG" in messages
+
+
+class TestCheckYearLifersTentativeAlerts:
+    @pytest.mark.asyncio
+    async def test_provisional_all_time_sends_tentative(self, mock_channel):
+        obs = make_obs(obs_reviewed=False)
+        await _run_check(
+            mock_channel,
+            check_for_new_all_time_lifers=MagicMock(
+                return_value=([], [obs])
+            ),
+        )
+        messages = [
+            call.args[0] for call in mock_channel.send.call_args_list
+        ]
+        assert "TENT_AT_MSG" in messages
+
+    @pytest.mark.asyncio
+    async def test_provisional_year_sends_tentative(self, mock_channel):
+        obs = make_obs(obs_reviewed=False)
+        await _run_check(
+            mock_channel,
+            check_for_new_year_lifers=MagicMock(return_value=([], [obs])),
+        )
+        messages = [
+            call.args[0] for call in mock_channel.send.call_args_list
+        ]
+        assert "TENT_YR_MSG" in messages
+
+
+class TestCheckYearLifersYearExcludedWhenAllTime:
+    @pytest.mark.asyncio
+    async def test_year_lifers_excluded_when_also_all_time(self, mock_channel):
+        """If a species is both a year lifer and an all-time lifer,
+        only the all-time alert should fire."""
+        obs = make_obs(obs_reviewed=True)
+        await _run_check(
+            mock_channel,
+            check_for_new_all_time_lifers=MagicMock(
+                return_value=([obs], [])
+            ),
+            # Year check also returns the same species
+            check_for_new_year_lifers=MagicMock(return_value=([obs], [])),
+        )
+        messages = [
+            call.args[0] for call in mock_channel.send.call_args_list
+        ]
+        assert "AT_MSG" in messages
+        # Year message should NOT be sent because the species overlaps
+        assert "YR_MSG" not in messages
+
+    @pytest.mark.asyncio
+    async def test_provisional_year_excluded_when_also_provisional_all_time(
+        self, mock_channel
+    ):
+        obs = make_obs(obs_reviewed=False)
+        await _run_check(
+            mock_channel,
+            check_for_new_all_time_lifers=MagicMock(
+                return_value=([], [obs])
+            ),
+            check_for_new_year_lifers=MagicMock(return_value=([], [obs])),
+        )
+        messages = [
+            call.args[0] for call in mock_channel.send.call_args_list
+        ]
+        assert "TENT_AT_MSG" in messages
+        assert "TENT_YR_MSG" not in messages
+
+
+class TestCheckYearLifersPendingFollowUp:
+    @pytest.mark.asyncio
+    async def test_pending_confirmed_sends_celebratory(self, mock_channel):
+        pending = make_pending(lifer_type="all_time")
+        await _run_check(
+            mock_channel,
+            check_pending_provisionals=AsyncMock(
+                return_value=([pending], [])
+            ),
+        )
+        messages = [
+            call.args[0] for call in mock_channel.send.call_args_list
+        ]
+        assert "CONF_AT_MSG" in messages
+
+    @pytest.mark.asyncio
+    async def test_pending_confirmed_year(self, mock_channel):
+        pending = make_pending(lifer_type="year")
+        await _run_check(
+            mock_channel,
+            check_pending_provisionals=AsyncMock(
+                return_value=([pending], [])
+            ),
+        )
+        messages = [
+            call.args[0] for call in mock_channel.send.call_args_list
+        ]
+        assert "CONF_YR_MSG" in messages
+
+    @pytest.mark.asyncio
+    async def test_pending_invalidated_sends_update(self, mock_channel):
+        pending = make_pending()
+        await _run_check(
+            mock_channel,
+            check_pending_provisionals=AsyncMock(
+                return_value=([], [pending])
+            ),
+        )
+        messages = [
+            call.args[0] for call in mock_channel.send.call_args_list
+        ]
+        assert "INVAL_MSG" in messages
+
+
+class TestCheckYearLifersNoActivity:
+    @pytest.mark.asyncio
+    async def test_no_lifers_sends_no_messages(self, mock_channel):
+        await _run_check(mock_channel)
+        mock_channel.send.assert_not_called()

--- a/tests/piper/test_main.py
+++ b/tests/piper/test_main.py
@@ -106,18 +106,10 @@ def patches(mock_channel):
         get_year_total=MagicMock(return_value=42),
         format_all_time_lifer_message=MagicMock(return_value="AT_MSG"),
         format_year_lifer_message=MagicMock(return_value="YR_MSG"),
-        format_tentative_all_time_lifer_message=MagicMock(
-            return_value="TENT_AT_MSG"
-        ),
-        format_tentative_year_lifer_message=MagicMock(
-            return_value="TENT_YR_MSG"
-        ),
-        format_confirmed_all_time_lifer_message=MagicMock(
-            return_value="CONF_AT_MSG"
-        ),
-        format_confirmed_year_lifer_message=MagicMock(
-            return_value="CONF_YR_MSG"
-        ),
+        format_tentative_all_time_lifer_message=MagicMock(return_value="TENT_AT_MSG"),
+        format_tentative_year_lifer_message=MagicMock(return_value="TENT_YR_MSG"),
+        format_confirmed_all_time_lifer_message=MagicMock(return_value="CONF_AT_MSG"),
+        format_confirmed_year_lifer_message=MagicMock(return_value="CONF_YR_MSG"),
         format_invalidated_lifer_message=MagicMock(return_value="INVAL_MSG"),
         all_time_list_link_view=MagicMock(return_value=None),
         year_list_link_view=MagicMock(return_value=None),
@@ -150,18 +142,10 @@ async def _run_check(mock_channel, **overrides):
         get_year_total=MagicMock(return_value=42),
         format_all_time_lifer_message=MagicMock(return_value="AT_MSG"),
         format_year_lifer_message=MagicMock(return_value="YR_MSG"),
-        format_tentative_all_time_lifer_message=MagicMock(
-            return_value="TENT_AT_MSG"
-        ),
-        format_tentative_year_lifer_message=MagicMock(
-            return_value="TENT_YR_MSG"
-        ),
-        format_confirmed_all_time_lifer_message=MagicMock(
-            return_value="CONF_AT_MSG"
-        ),
-        format_confirmed_year_lifer_message=MagicMock(
-            return_value="CONF_YR_MSG"
-        ),
+        format_tentative_all_time_lifer_message=MagicMock(return_value="TENT_AT_MSG"),
+        format_tentative_year_lifer_message=MagicMock(return_value="TENT_YR_MSG"),
+        format_confirmed_all_time_lifer_message=MagicMock(return_value="CONF_AT_MSG"),
+        format_confirmed_year_lifer_message=MagicMock(return_value="CONF_YR_MSG"),
         format_invalidated_lifer_message=MagicMock(return_value="INVAL_MSG"),
         all_time_list_link_view=MagicMock(return_value=None),
         year_list_link_view=MagicMock(return_value=None),
@@ -171,10 +155,13 @@ async def _run_check(mock_channel, **overrides):
     mock_bot = MagicMock()
     mock_bot.get_channel = MagicMock(return_value=mock_channel)
 
-    with patch.multiple(MODULE, **default_mocks), \
-         patch(f"{MODULE}.bot", mock_bot), \
-         patch(f"{MODULE}._last_year_lifer_check", None):
+    with (
+        patch.multiple(MODULE, **default_mocks),
+        patch(f"{MODULE}.bot", mock_bot),
+        patch(f"{MODULE}._last_year_lifer_check", None),
+    ):
         from cloaca.piper.main import check_year_lifers
+
         await check_year_lifers.coro()
 
 
@@ -185,19 +172,13 @@ async def _run_check(mock_channel, **overrides):
 
 class TestCheckYearLifersConfirmedAlerts:
     @pytest.mark.asyncio
-    async def test_confirmed_all_time_lifer_sends_full_alert(
-        self, mock_channel
-    ):
+    async def test_confirmed_all_time_lifer_sends_full_alert(self, mock_channel):
         obs = make_obs(obs_reviewed=True)
         await _run_check(
             mock_channel,
-            check_for_new_all_time_lifers=MagicMock(
-                return_value=([obs], [])
-            ),
+            check_for_new_all_time_lifers=MagicMock(return_value=([obs], [])),
         )
-        messages = [
-            call.args[0] for call in mock_channel.send.call_args_list
-        ]
+        messages = [call.args[0] for call in mock_channel.send.call_args_list]
         assert "AT_MSG" in messages
 
     @pytest.mark.asyncio
@@ -207,9 +188,7 @@ class TestCheckYearLifersConfirmedAlerts:
             mock_channel,
             check_for_new_year_lifers=MagicMock(return_value=([obs], [])),
         )
-        messages = [
-            call.args[0] for call in mock_channel.send.call_args_list
-        ]
+        messages = [call.args[0] for call in mock_channel.send.call_args_list]
         assert "YR_MSG" in messages
 
 
@@ -219,13 +198,9 @@ class TestCheckYearLifersTentativeAlerts:
         obs = make_obs(obs_reviewed=False)
         await _run_check(
             mock_channel,
-            check_for_new_all_time_lifers=MagicMock(
-                return_value=([], [obs])
-            ),
+            check_for_new_all_time_lifers=MagicMock(return_value=([], [obs])),
         )
-        messages = [
-            call.args[0] for call in mock_channel.send.call_args_list
-        ]
+        messages = [call.args[0] for call in mock_channel.send.call_args_list]
         assert "TENT_AT_MSG" in messages
 
     @pytest.mark.asyncio
@@ -235,9 +210,7 @@ class TestCheckYearLifersTentativeAlerts:
             mock_channel,
             check_for_new_year_lifers=MagicMock(return_value=([], [obs])),
         )
-        messages = [
-            call.args[0] for call in mock_channel.send.call_args_list
-        ]
+        messages = [call.args[0] for call in mock_channel.send.call_args_list]
         assert "TENT_YR_MSG" in messages
 
 
@@ -249,15 +222,11 @@ class TestCheckYearLifersYearExcludedWhenAllTime:
         obs = make_obs(obs_reviewed=True)
         await _run_check(
             mock_channel,
-            check_for_new_all_time_lifers=MagicMock(
-                return_value=([obs], [])
-            ),
+            check_for_new_all_time_lifers=MagicMock(return_value=([obs], [])),
             # Year check also returns the same species
             check_for_new_year_lifers=MagicMock(return_value=([obs], [])),
         )
-        messages = [
-            call.args[0] for call in mock_channel.send.call_args_list
-        ]
+        messages = [call.args[0] for call in mock_channel.send.call_args_list]
         assert "AT_MSG" in messages
         # Year message should NOT be sent because the species overlaps
         assert "YR_MSG" not in messages
@@ -269,14 +238,10 @@ class TestCheckYearLifersYearExcludedWhenAllTime:
         obs = make_obs(obs_reviewed=False)
         await _run_check(
             mock_channel,
-            check_for_new_all_time_lifers=MagicMock(
-                return_value=([], [obs])
-            ),
+            check_for_new_all_time_lifers=MagicMock(return_value=([], [obs])),
             check_for_new_year_lifers=MagicMock(return_value=([], [obs])),
         )
-        messages = [
-            call.args[0] for call in mock_channel.send.call_args_list
-        ]
+        messages = [call.args[0] for call in mock_channel.send.call_args_list]
         assert "TENT_AT_MSG" in messages
         assert "TENT_YR_MSG" not in messages
 
@@ -287,13 +252,9 @@ class TestCheckYearLifersPendingFollowUp:
         pending = make_pending(lifer_type="all_time")
         await _run_check(
             mock_channel,
-            check_pending_provisionals=AsyncMock(
-                return_value=([pending], [])
-            ),
+            check_pending_provisionals=AsyncMock(return_value=([pending], [])),
         )
-        messages = [
-            call.args[0] for call in mock_channel.send.call_args_list
-        ]
+        messages = [call.args[0] for call in mock_channel.send.call_args_list]
         assert "CONF_AT_MSG" in messages
 
     @pytest.mark.asyncio
@@ -301,13 +262,9 @@ class TestCheckYearLifersPendingFollowUp:
         pending = make_pending(lifer_type="year")
         await _run_check(
             mock_channel,
-            check_pending_provisionals=AsyncMock(
-                return_value=([pending], [])
-            ),
+            check_pending_provisionals=AsyncMock(return_value=([pending], [])),
         )
-        messages = [
-            call.args[0] for call in mock_channel.send.call_args_list
-        ]
+        messages = [call.args[0] for call in mock_channel.send.call_args_list]
         assert "CONF_YR_MSG" in messages
 
     @pytest.mark.asyncio
@@ -315,13 +272,9 @@ class TestCheckYearLifersPendingFollowUp:
         pending = make_pending()
         await _run_check(
             mock_channel,
-            check_pending_provisionals=AsyncMock(
-                return_value=([], [pending])
-            ),
+            check_pending_provisionals=AsyncMock(return_value=([], [pending])),
         )
-        messages = [
-            call.args[0] for call in mock_channel.send.call_args_list
-        ]
+        messages = [call.args[0] for call in mock_channel.send.call_args_list]
         assert "INVAL_MSG" in messages
 
 

--- a/tests/piper/test_year_lifers.py
+++ b/tests/piper/test_year_lifers.py
@@ -34,9 +34,7 @@ from cloaca.piper.year_lifers import (
 from cloaca.scripts.fetch_yearly_hotspot_data import eBirdHistoricFullObservation
 
 HOTSPOT_ID = "L1814508"
-YEAR = datetime.datetime.now(
-    datetime.timezone(datetime.timedelta(hours=-5))
-).year
+YEAR = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=-5))).year
 
 
 # ---------------------------------------------------------------------------
@@ -174,9 +172,7 @@ class TestSplitConfirmedProvisional:
         unreviewed = make_obs("yetwar", obs_reviewed=False)
         new_lifers = [reviewed, unreviewed]
         all_obs = [reviewed, unreviewed]
-        confirmed, provisional = _split_confirmed_provisional(
-            new_lifers, all_obs
-        )
+        confirmed, provisional = _split_confirmed_provisional(new_lifers, all_obs)
         assert [o.speciesCode for o in confirmed] == ["amrob"]
         assert [o.speciesCode for o in provisional] == ["yetwar"]
 
@@ -196,9 +192,7 @@ class TestSplitConfirmedProvisional:
         # _find_new_species would return the earliest
         new_lifers = [earliest]
         all_obs = [earliest, later_reviewed]
-        confirmed, provisional = _split_confirmed_provisional(
-            new_lifers, all_obs
-        )
+        confirmed, provisional = _split_confirmed_provisional(new_lifers, all_obs)
         assert len(confirmed) == 1
         assert len(provisional) == 0
 
@@ -359,17 +353,13 @@ class TestCheckForNewYearLifers:
 class TestCheckForNewAllTimeLifers:
     def test_confirmed_lifer(self):
         obs = [make_obs(obs_reviewed=True)]
-        confirmed, provisional = check_for_new_all_time_lifers(
-            HOTSPOT_ID, obs
-        )
+        confirmed, provisional = check_for_new_all_time_lifers(HOTSPOT_ID, obs)
         assert len(confirmed) == 1
         assert "yetwar" in _get_known_all_time_species(HOTSPOT_ID)
 
     def test_provisional_lifer(self):
         obs = [make_obs(obs_reviewed=False)]
-        confirmed, provisional = check_for_new_all_time_lifers(
-            HOTSPOT_ID, obs
-        )
+        confirmed, provisional = check_for_new_all_time_lifers(HOTSPOT_ID, obs)
         assert len(provisional) == 1
         assert "yetwar" in _get_known_all_time_species(HOTSPOT_ID)
         pending = _get_pending_provisionals(HOTSPOT_ID)
@@ -379,9 +369,7 @@ class TestCheckForNewAllTimeLifers:
     def test_already_known_species_not_detected(self):
         _insert_all_time_species(HOTSPOT_ID, "yetwar")
         obs = [make_obs(obs_reviewed=True)]
-        confirmed, provisional = check_for_new_all_time_lifers(
-            HOTSPOT_ID, obs
-        )
+        confirmed, provisional = check_for_new_all_time_lifers(HOTSPOT_ID, obs)
         assert confirmed == []
         assert provisional == []
 
@@ -394,9 +382,7 @@ class TestCheckForNewAllTimeLifers:
 class TestCheckPendingProvisionals:
     @pytest.mark.asyncio
     async def test_no_pending_returns_empty(self):
-        confirmed, invalidated = await check_pending_provisionals(
-            HOTSPOT_ID, []
-        )
+        confirmed, invalidated = await check_pending_provisionals(HOTSPOT_ID, [])
         assert confirmed == []
         assert invalidated == []
 
@@ -408,11 +394,10 @@ class TestCheckPendingProvisionals:
         _insert_pending_provisional(HOTSPOT_ID, obs, "year", YEAR)
         _insert_species(HOTSPOT_ID, YEAR, obs)
 
-        now = datetime.datetime.now(
-            datetime.timezone(datetime.timedelta(hours=-5))
-        )
+        now = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=-5)))
         reviewed = make_obs(
-            obs_reviewed=True, obs_dt=now,
+            obs_reviewed=True,
+            obs_dt=now,
         )
 
         confirmed, invalidated = await check_pending_provisionals(
@@ -427,16 +412,12 @@ class TestCheckPendingProvisionals:
     @pytest.mark.asyncio
     async def test_still_pending_when_unreviewed(self):
         """Observation still unreviewed — no change."""
-        now = datetime.datetime.now(
-            datetime.timezone(datetime.timedelta(hours=-5))
-        )
+        now = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=-5)))
         obs = make_obs(obs_reviewed=False, obs_dt=now)
         _insert_pending_provisional(HOTSPOT_ID, obs, "year", YEAR)
         _insert_species(HOTSPOT_ID, YEAR, obs)
 
-        confirmed, invalidated = await check_pending_provisionals(
-            HOTSPOT_ID, [obs]
-        )
+        confirmed, invalidated = await check_pending_provisionals(HOTSPOT_ID, [obs])
         assert confirmed == []
         assert invalidated == []
         # Still in pending table
@@ -447,9 +428,7 @@ class TestCheckPendingProvisionals:
         """Observation vanishes from API for >14 days → invalidated."""
         old_date = datetime.date.today() - datetime.timedelta(days=20)
         obs = make_obs(
-            obs_dt=datetime.datetime(
-                old_date.year, old_date.month, old_date.day, 8, 0
-            )
+            obs_dt=datetime.datetime(old_date.year, old_date.month, old_date.day, 8, 0)
         )
         _insert_pending_provisional(HOTSPOT_ID, obs, "year", YEAR)
         _insert_species(HOTSPOT_ID, YEAR, obs)
@@ -459,9 +438,7 @@ class TestCheckPendingProvisionals:
             new_callable=AsyncMock,
             return_value=[],  # observation gone
         ):
-            confirmed, invalidated = await check_pending_provisionals(
-                HOTSPOT_ID, []
-            )
+            confirmed, invalidated = await check_pending_provisionals(HOTSPOT_ID, [])
 
         assert confirmed == []
         assert len(invalidated) == 1
@@ -475,9 +452,7 @@ class TestCheckPendingProvisionals:
     async def test_invalidated_all_time_removes_from_known(self):
         old_date = datetime.date.today() - datetime.timedelta(days=20)
         obs = make_obs(
-            obs_dt=datetime.datetime(
-                old_date.year, old_date.month, old_date.day, 8, 0
-            )
+            obs_dt=datetime.datetime(old_date.year, old_date.month, old_date.day, 8, 0)
         )
         _insert_pending_provisional(HOTSPOT_ID, obs, "all_time")
         _insert_all_time_species(HOTSPOT_ID, "yetwar")
@@ -487,9 +462,7 @@ class TestCheckPendingProvisionals:
             new_callable=AsyncMock,
             return_value=[],
         ):
-            confirmed, invalidated = await check_pending_provisionals(
-                HOTSPOT_ID, []
-            )
+            confirmed, invalidated = await check_pending_provisionals(HOTSPOT_ID, [])
 
         assert len(invalidated) == 1
         assert "yetwar" not in _get_known_all_time_species(HOTSPOT_ID)
@@ -511,9 +484,7 @@ class TestCheckPendingProvisionals:
             new_callable=AsyncMock,
             return_value=[],
         ):
-            confirmed, invalidated = await check_pending_provisionals(
-                HOTSPOT_ID, []
-            )
+            confirmed, invalidated = await check_pending_provisionals(HOTSPOT_ID, [])
 
         assert confirmed == []
         assert invalidated == []
@@ -526,18 +497,14 @@ class TestCheckPendingProvisionals:
         date rather than relying on today/yesterday only."""
         old_date = datetime.date.today() - datetime.timedelta(days=5)
         obs = make_obs(
-            obs_dt=datetime.datetime(
-                old_date.year, old_date.month, old_date.day, 8, 0
-            )
+            obs_dt=datetime.datetime(old_date.year, old_date.month, old_date.day, 8, 0)
         )
         _insert_pending_provisional(HOTSPOT_ID, obs, "year", YEAR)
         _insert_species(HOTSPOT_ID, YEAR, obs)
 
         reviewed = make_obs(
             obs_reviewed=True,
-            obs_dt=datetime.datetime(
-                old_date.year, old_date.month, old_date.day, 8, 0
-            ),
+            obs_dt=datetime.datetime(old_date.year, old_date.month, old_date.day, 8, 0),
         )
 
         with patch(
@@ -546,7 +513,8 @@ class TestCheckPendingProvisionals:
             return_value=[reviewed],
         ) as mock_fetch:
             confirmed, invalidated = await check_pending_provisionals(
-                HOTSPOT_ID, []  # no recent observations
+                HOTSPOT_ID,
+                [],  # no recent observations
             )
 
         mock_fetch.assert_called_once_with(HOTSPOT_ID, old_date)
@@ -589,9 +557,7 @@ class TestFormatAllTimeLiferMessage:
     def test_multiple(self):
         obs1 = make_obs("amrob", "American Robin")
         obs2 = make_obs("yetwar", "Yellow-throated Warbler")
-        msg = format_all_time_lifer_message(
-            [obs1, obs2], "Franz Sigel Park", 100
-        )
+        msg = format_all_time_lifer_message([obs1, obs2], "Franz Sigel Park", 100)
         assert "2 New Park Birds" in msg
         assert "100 species all-time" in msg
 
@@ -613,17 +579,13 @@ class TestFormatTentativeMessages:
     def test_tentative_year_multiple(self):
         obs1 = make_obs("amrob", "American Robin")
         obs2 = make_obs("yetwar", "Yellow-throated Warbler")
-        msg = format_tentative_year_lifer_message(
-            [obs1, obs2], "Franz Sigel Park"
-        )
+        msg = format_tentative_year_lifer_message([obs1, obs2], "Franz Sigel Park")
         assert "2 Possible New Year Birds" in msg
         assert "Awaiting eBird review" in msg
 
     def test_tentative_all_time_single(self):
         obs = make_obs()
-        msg = format_tentative_all_time_lifer_message(
-            [obs], "Franz Sigel Park"
-        )
+        msg = format_tentative_all_time_lifer_message([obs], "Franz Sigel Park")
         assert "Possible New Park Bird" in msg
         assert "Yellow-throated Warbler" in msg
         assert "Awaiting eBird review" in msg
@@ -631,9 +593,7 @@ class TestFormatTentativeMessages:
     def test_tentative_all_time_multiple(self):
         obs1 = make_obs("amrob", "American Robin")
         obs2 = make_obs("yetwar", "Yellow-throated Warbler")
-        msg = format_tentative_all_time_lifer_message(
-            [obs1, obs2], "Franz Sigel Park"
-        )
+        msg = format_tentative_all_time_lifer_message([obs1, obs2], "Franz Sigel Park")
         assert "2 Possible New Park Birds" in msg
 
 
@@ -660,9 +620,7 @@ class TestFormatConfirmedMessages:
 
     def test_confirmed_year_single(self):
         p = self._pending()
-        msg = format_confirmed_year_lifer_message(
-            [p], "Franz Sigel Park", 42
-        )
+        msg = format_confirmed_year_lifer_message([p], "Franz Sigel Park", 42)
         assert "Confirmed!" in msg
         assert "Year Bird #42" in msg
         assert "Yellow-throated Warbler" in msg
@@ -671,17 +629,13 @@ class TestFormatConfirmedMessages:
     def test_confirmed_year_multiple(self):
         p1 = self._pending(species_code="amrob", common_name="American Robin")
         p2 = self._pending()
-        msg = format_confirmed_year_lifer_message(
-            [p1, p2], "Franz Sigel Park", 42
-        )
+        msg = format_confirmed_year_lifer_message([p1, p2], "Franz Sigel Park", 42)
         assert "2 Year Birds Confirmed" in msg
         assert "42 species" in msg
 
     def test_confirmed_all_time_single(self):
         p = self._pending(lifer_type="all_time")
-        msg = format_confirmed_all_time_lifer_message(
-            [p], "Franz Sigel Park", 100
-        )
+        msg = format_confirmed_all_time_lifer_message([p], "Franz Sigel Park", 100)
         assert "Confirmed!" in msg
         assert "New Park Bird" in msg
         assert "#100 all-time" in msg
@@ -693,9 +647,7 @@ class TestFormatConfirmedMessages:
             lifer_type="all_time",
         )
         p2 = self._pending(lifer_type="all_time")
-        msg = format_confirmed_all_time_lifer_message(
-            [p1, p2], "Franz Sigel Park", 100
-        )
+        msg = format_confirmed_all_time_lifer_message([p1, p2], "Franz Sigel Park", 100)
         assert "2 New Park Birds Confirmed" in msg
 
 

--- a/tests/piper/test_year_lifers.py
+++ b/tests/piper/test_year_lifers.py
@@ -1,0 +1,749 @@
+import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cloaca.piper.year_lifers import (
+    PendingProvisional,
+    _find_new_species,
+    _get_known_all_time_species,
+    _get_known_species,
+    _get_pending_provisionals,
+    _insert_all_time_species,
+    _insert_pending_provisional,
+    _insert_species,
+    _remove_all_time_species,
+    _remove_pending_provisional,
+    _remove_year_species,
+    _split_confirmed_provisional,
+    check_for_new_all_time_lifers,
+    check_for_new_year_lifers,
+    check_pending_provisionals,
+    close_state_db,
+    format_all_time_lifer_message,
+    format_confirmed_all_time_lifer_message,
+    format_confirmed_year_lifer_message,
+    format_invalidated_lifer_message,
+    format_tentative_all_time_lifer_message,
+    format_tentative_year_lifer_message,
+    format_year_lifer_message,
+    get_all_time_total,
+    get_state_db,
+    get_year_total,
+)
+from cloaca.scripts.fetch_yearly_hotspot_data import eBirdHistoricFullObservation
+
+HOTSPOT_ID = "L1814508"
+YEAR = datetime.datetime.now(
+    datetime.timezone(datetime.timedelta(hours=-5))
+).year
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_obs(
+    species_code: str = "yetwar",
+    com_name: str = "Yellow-throated Warbler",
+    sci_name: str = "Setophaga dominica",
+    obs_dt: datetime.datetime | None = None,
+    checklist_id: str = "S100001",
+    user_display_name: str = "Jane Doe",
+    obs_reviewed: bool = False,
+    obs_valid: bool = True,
+    exotic_category: str | None = None,
+) -> eBirdHistoricFullObservation:
+    if obs_dt is None:
+        obs_dt = datetime.datetime(2026, 4, 11, 8, 30)
+    return eBirdHistoricFullObservation(
+        speciesCode=species_code,
+        comName=com_name,
+        sciName=sci_name,
+        locId=HOTSPOT_ID,
+        locName="Franz Sigel Park",
+        obsDt=obs_dt,
+        lat=40.83,
+        lng=-73.92,
+        obsValid=obs_valid,
+        obsReviewed=obs_reviewed,
+        locationPrivate=False,
+        subId="S100001",
+        subnational2Code="US-NY-005",
+        subnational2Name="Bronx",
+        subnational1Code="US-NY",
+        subnational1Name="New York",
+        countryCode="US",
+        countryName="United States",
+        userDisplayName=user_display_name,
+        obsId=f"OBS{species_code}",
+        checklistId=checklist_id,
+        presenceNoted=False,
+        hasComments=False,
+        firstName="Jane",
+        lastName="Doe",
+        hasRichMedia=False,
+        exoticCategory=exotic_category,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def state_db(tmp_path, monkeypatch):
+    """Provide a fresh DuckDB state DB for each test."""
+    db_path = str(tmp_path / "test_state.db")
+    monkeypatch.setenv("PIPER_STATE_DB_PATH", db_path)
+    close_state_db()
+    db = get_state_db()
+    yield db
+    close_state_db()
+
+
+# ---------------------------------------------------------------------------
+# _find_new_species
+# ---------------------------------------------------------------------------
+
+
+class TestFindNewSpecies:
+    def test_finds_new_species(self):
+        obs = [make_obs("amrob", "American Robin"), make_obs("yetwar")]
+        known = {"amrob"}
+        result = _find_new_species(obs, known)
+        assert len(result) == 1
+        assert result[0].speciesCode == "yetwar"
+
+    def test_returns_empty_when_all_known(self):
+        obs = [make_obs("amrob"), make_obs("yetwar")]
+        known = {"amrob", "yetwar"}
+        assert _find_new_species(obs, known) == []
+
+    def test_returns_empty_for_empty_observations(self):
+        assert _find_new_species([], set()) == []
+
+    def test_picks_earliest_observation_per_species(self):
+        early = make_obs(
+            obs_dt=datetime.datetime(2026, 4, 11, 7, 0),
+            checklist_id="S_early",
+            user_display_name="Early Bird",
+        )
+        late = make_obs(
+            obs_dt=datetime.datetime(2026, 4, 11, 10, 0),
+            checklist_id="S_late",
+            user_display_name="Late Bird",
+        )
+        result = _find_new_species([late, early], set())
+        assert len(result) == 1
+        assert result[0].checklistId == "S_early"
+
+    def test_handles_multiple_new_species(self):
+        obs = [
+            make_obs("amrob", "American Robin"),
+            make_obs("yetwar", "Yellow-throated Warbler"),
+            make_obs("bkcchi", "Black-capped Chickadee"),
+        ]
+        result = _find_new_species(obs, set())
+        codes = {o.speciesCode for o in result}
+        assert codes == {"amrob", "yetwar", "bkcchi"}
+
+
+# ---------------------------------------------------------------------------
+# _split_confirmed_provisional
+# ---------------------------------------------------------------------------
+
+
+class TestSplitConfirmedProvisional:
+    def test_all_reviewed(self):
+        obs = [make_obs(obs_reviewed=True)]
+        confirmed, provisional = _split_confirmed_provisional(obs, obs)
+        assert len(confirmed) == 1
+        assert len(provisional) == 0
+
+    def test_all_unreviewed(self):
+        obs = [make_obs(obs_reviewed=False)]
+        confirmed, provisional = _split_confirmed_provisional(obs, obs)
+        assert len(confirmed) == 0
+        assert len(provisional) == 1
+
+    def test_mixed(self):
+        reviewed = make_obs("amrob", "American Robin", obs_reviewed=True)
+        unreviewed = make_obs("yetwar", obs_reviewed=False)
+        new_lifers = [reviewed, unreviewed]
+        all_obs = [reviewed, unreviewed]
+        confirmed, provisional = _split_confirmed_provisional(
+            new_lifers, all_obs
+        )
+        assert [o.speciesCode for o in confirmed] == ["amrob"]
+        assert [o.speciesCode for o in provisional] == ["yetwar"]
+
+    def test_confirmed_if_any_observation_of_species_reviewed(self):
+        """Even if the earliest obs is unreviewed, if another observer's
+        record is reviewed, the species counts as confirmed."""
+        earliest = make_obs(
+            obs_reviewed=False,
+            checklist_id="S_unreviewed",
+            obs_dt=datetime.datetime(2026, 4, 11, 7, 0),
+        )
+        later_reviewed = make_obs(
+            obs_reviewed=True,
+            checklist_id="S_reviewed",
+            obs_dt=datetime.datetime(2026, 4, 11, 9, 0),
+        )
+        # _find_new_species would return the earliest
+        new_lifers = [earliest]
+        all_obs = [earliest, later_reviewed]
+        confirmed, provisional = _split_confirmed_provisional(
+            new_lifers, all_obs
+        )
+        assert len(confirmed) == 1
+        assert len(provisional) == 0
+
+
+# ---------------------------------------------------------------------------
+# DB: year species helpers
+# ---------------------------------------------------------------------------
+
+
+class TestYearSpeciesDB:
+    def test_insert_and_get_known(self):
+        obs = make_obs()
+        _insert_species(HOTSPOT_ID, YEAR, obs)
+        known = _get_known_species(HOTSPOT_ID, YEAR)
+        assert "yetwar" in known
+
+    def test_get_year_total(self):
+        assert get_year_total(HOTSPOT_ID) == 0
+        _insert_species(HOTSPOT_ID, YEAR, make_obs("amrob", "American Robin"))
+        _insert_species(HOTSPOT_ID, YEAR, make_obs("yetwar"))
+        assert get_year_total(HOTSPOT_ID) == 2
+
+    def test_remove_year_species(self):
+        _insert_species(HOTSPOT_ID, YEAR, make_obs())
+        assert get_year_total(HOTSPOT_ID) == 1
+        _remove_year_species(HOTSPOT_ID, YEAR, "yetwar")
+        assert get_year_total(HOTSPOT_ID) == 0
+
+    def test_insert_duplicate_is_noop(self):
+        obs = make_obs()
+        _insert_species(HOTSPOT_ID, YEAR, obs)
+        _insert_species(HOTSPOT_ID, YEAR, obs)
+        assert get_year_total(HOTSPOT_ID) == 1
+
+
+# ---------------------------------------------------------------------------
+# DB: all-time species helpers
+# ---------------------------------------------------------------------------
+
+
+class TestAllTimeSpeciesDB:
+    def test_insert_and_get_known(self):
+        _insert_all_time_species(HOTSPOT_ID, "yetwar")
+        known = _get_known_all_time_species(HOTSPOT_ID)
+        assert "yetwar" in known
+
+    def test_get_all_time_total(self):
+        assert get_all_time_total(HOTSPOT_ID) == 0
+        _insert_all_time_species(HOTSPOT_ID, "amrob")
+        _insert_all_time_species(HOTSPOT_ID, "yetwar")
+        assert get_all_time_total(HOTSPOT_ID) == 2
+
+    def test_remove_all_time_species(self):
+        _insert_all_time_species(HOTSPOT_ID, "yetwar")
+        assert get_all_time_total(HOTSPOT_ID) == 1
+        _remove_all_time_species(HOTSPOT_ID, "yetwar")
+        assert get_all_time_total(HOTSPOT_ID) == 0
+
+
+# ---------------------------------------------------------------------------
+# DB: pending provisional helpers
+# ---------------------------------------------------------------------------
+
+
+class TestPendingProvisionalDB:
+    def test_insert_and_get(self):
+        obs = make_obs()
+        _insert_pending_provisional(HOTSPOT_ID, obs, "year", YEAR)
+        pending = _get_pending_provisionals(HOTSPOT_ID)
+        assert len(pending) == 1
+        p = pending[0]
+        assert p.species_code == "yetwar"
+        assert p.common_name == "Yellow-throated Warbler"
+        assert p.lifer_type == "year"
+        assert p.year == YEAR
+        assert isinstance(p.obs_date, datetime.date)
+
+    def test_remove(self):
+        obs = make_obs()
+        _insert_pending_provisional(HOTSPOT_ID, obs, "year", YEAR)
+        _remove_pending_provisional(HOTSPOT_ID, "yetwar", "year")
+        assert _get_pending_provisionals(HOTSPOT_ID) == []
+
+    def test_empty_when_no_records(self):
+        assert _get_pending_provisionals(HOTSPOT_ID) == []
+
+    def test_duplicate_insert_is_noop(self):
+        obs = make_obs()
+        _insert_pending_provisional(HOTSPOT_ID, obs, "year", YEAR)
+        _insert_pending_provisional(HOTSPOT_ID, obs, "year", YEAR)
+        assert len(_get_pending_provisionals(HOTSPOT_ID)) == 1
+
+    def test_same_species_different_lifer_types(self):
+        obs = make_obs()
+        _insert_pending_provisional(HOTSPOT_ID, obs, "year", YEAR)
+        _insert_pending_provisional(HOTSPOT_ID, obs, "all_time")
+        pending = _get_pending_provisionals(HOTSPOT_ID)
+        assert len(pending) == 2
+        types = {p.lifer_type for p in pending}
+        assert types == {"year", "all_time"}
+
+
+# ---------------------------------------------------------------------------
+# check_for_new_year_lifers
+# ---------------------------------------------------------------------------
+
+
+class TestCheckForNewYearLifers:
+    def test_confirmed_lifer(self):
+        obs = [make_obs(obs_reviewed=True)]
+        confirmed, provisional = check_for_new_year_lifers(HOTSPOT_ID, obs)
+        assert len(confirmed) == 1
+        assert len(provisional) == 0
+        # Should be inserted into known species
+        assert "yetwar" in _get_known_species(HOTSPOT_ID, YEAR)
+
+    def test_provisional_lifer(self):
+        obs = [make_obs(obs_reviewed=False)]
+        confirmed, provisional = check_for_new_year_lifers(HOTSPOT_ID, obs)
+        assert len(confirmed) == 0
+        assert len(provisional) == 1
+        # Should still be inserted into known species
+        assert "yetwar" in _get_known_species(HOTSPOT_ID, YEAR)
+        # Should create a pending provisional
+        pending = _get_pending_provisionals(HOTSPOT_ID)
+        assert len(pending) == 1
+        assert pending[0].lifer_type == "year"
+
+    def test_empty_observations(self):
+        confirmed, provisional = check_for_new_year_lifers(HOTSPOT_ID, [])
+        assert confirmed == []
+        assert provisional == []
+
+    def test_already_known_species_not_detected(self):
+        _insert_species(HOTSPOT_ID, YEAR, make_obs())
+        obs = [make_obs(obs_reviewed=True)]
+        confirmed, provisional = check_for_new_year_lifers(HOTSPOT_ID, obs)
+        assert confirmed == []
+        assert provisional == []
+
+    def test_mixed_confirmed_and_provisional(self):
+        obs = [
+            make_obs("amrob", "American Robin", obs_reviewed=True),
+            make_obs("yetwar", "Yellow-throated Warbler", obs_reviewed=False),
+        ]
+        confirmed, provisional = check_for_new_year_lifers(HOTSPOT_ID, obs)
+        assert len(confirmed) == 1
+        assert confirmed[0].speciesCode == "amrob"
+        assert len(provisional) == 1
+        assert provisional[0].speciesCode == "yetwar"
+
+
+# ---------------------------------------------------------------------------
+# check_for_new_all_time_lifers
+# ---------------------------------------------------------------------------
+
+
+class TestCheckForNewAllTimeLifers:
+    def test_confirmed_lifer(self):
+        obs = [make_obs(obs_reviewed=True)]
+        confirmed, provisional = check_for_new_all_time_lifers(
+            HOTSPOT_ID, obs
+        )
+        assert len(confirmed) == 1
+        assert "yetwar" in _get_known_all_time_species(HOTSPOT_ID)
+
+    def test_provisional_lifer(self):
+        obs = [make_obs(obs_reviewed=False)]
+        confirmed, provisional = check_for_new_all_time_lifers(
+            HOTSPOT_ID, obs
+        )
+        assert len(provisional) == 1
+        assert "yetwar" in _get_known_all_time_species(HOTSPOT_ID)
+        pending = _get_pending_provisionals(HOTSPOT_ID)
+        assert len(pending) == 1
+        assert pending[0].lifer_type == "all_time"
+
+    def test_already_known_species_not_detected(self):
+        _insert_all_time_species(HOTSPOT_ID, "yetwar")
+        obs = [make_obs(obs_reviewed=True)]
+        confirmed, provisional = check_for_new_all_time_lifers(
+            HOTSPOT_ID, obs
+        )
+        assert confirmed == []
+        assert provisional == []
+
+
+# ---------------------------------------------------------------------------
+# check_pending_provisionals
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPendingProvisionals:
+    @pytest.mark.asyncio
+    async def test_no_pending_returns_empty(self):
+        confirmed, invalidated = await check_pending_provisionals(
+            HOTSPOT_ID, []
+        )
+        assert confirmed == []
+        assert invalidated == []
+
+    @pytest.mark.asyncio
+    async def test_confirmed_when_reviewed_in_recent_obs(self):
+        """Pending provisional is confirmed when its species appears reviewed
+        in the recent observations (today/yesterday)."""
+        obs = make_obs(obs_reviewed=False)
+        _insert_pending_provisional(HOTSPOT_ID, obs, "year", YEAR)
+        _insert_species(HOTSPOT_ID, YEAR, obs)
+
+        now = datetime.datetime.now(
+            datetime.timezone(datetime.timedelta(hours=-5))
+        )
+        reviewed = make_obs(
+            obs_reviewed=True, obs_dt=now,
+        )
+
+        confirmed, invalidated = await check_pending_provisionals(
+            HOTSPOT_ID, [reviewed]
+        )
+        assert len(confirmed) == 1
+        assert confirmed[0].species_code == "yetwar"
+        assert invalidated == []
+        # Pending record should be cleaned up
+        assert _get_pending_provisionals(HOTSPOT_ID) == []
+
+    @pytest.mark.asyncio
+    async def test_still_pending_when_unreviewed(self):
+        """Observation still unreviewed — no change."""
+        now = datetime.datetime.now(
+            datetime.timezone(datetime.timedelta(hours=-5))
+        )
+        obs = make_obs(obs_reviewed=False, obs_dt=now)
+        _insert_pending_provisional(HOTSPOT_ID, obs, "year", YEAR)
+        _insert_species(HOTSPOT_ID, YEAR, obs)
+
+        confirmed, invalidated = await check_pending_provisionals(
+            HOTSPOT_ID, [obs]
+        )
+        assert confirmed == []
+        assert invalidated == []
+        # Still in pending table
+        assert len(_get_pending_provisionals(HOTSPOT_ID)) == 1
+
+    @pytest.mark.asyncio
+    async def test_invalidated_after_stale_period(self):
+        """Observation vanishes from API for >14 days → invalidated."""
+        old_date = datetime.date.today() - datetime.timedelta(days=20)
+        obs = make_obs(
+            obs_dt=datetime.datetime(
+                old_date.year, old_date.month, old_date.day, 8, 0
+            )
+        )
+        _insert_pending_provisional(HOTSPOT_ID, obs, "year", YEAR)
+        _insert_species(HOTSPOT_ID, YEAR, obs)
+
+        with patch(
+            "cloaca.piper.year_lifers.fetch_observations_for_date",
+            new_callable=AsyncMock,
+            return_value=[],  # observation gone
+        ):
+            confirmed, invalidated = await check_pending_provisionals(
+                HOTSPOT_ID, []
+            )
+
+        assert confirmed == []
+        assert len(invalidated) == 1
+        assert invalidated[0].species_code == "yetwar"
+        # Cleaned up from pending
+        assert _get_pending_provisionals(HOTSPOT_ID) == []
+        # Also removed from known year species
+        assert "yetwar" not in _get_known_species(HOTSPOT_ID, YEAR)
+
+    @pytest.mark.asyncio
+    async def test_invalidated_all_time_removes_from_known(self):
+        old_date = datetime.date.today() - datetime.timedelta(days=20)
+        obs = make_obs(
+            obs_dt=datetime.datetime(
+                old_date.year, old_date.month, old_date.day, 8, 0
+            )
+        )
+        _insert_pending_provisional(HOTSPOT_ID, obs, "all_time")
+        _insert_all_time_species(HOTSPOT_ID, "yetwar")
+
+        with patch(
+            "cloaca.piper.year_lifers.fetch_observations_for_date",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            confirmed, invalidated = await check_pending_provisionals(
+                HOTSPOT_ID, []
+            )
+
+        assert len(invalidated) == 1
+        assert "yetwar" not in _get_known_all_time_species(HOTSPOT_ID)
+
+    @pytest.mark.asyncio
+    async def test_not_invalidated_before_stale_period(self):
+        """Observation gone but only 5 days old — don't invalidate yet."""
+        recent_date = datetime.date.today() - datetime.timedelta(days=5)
+        obs = make_obs(
+            obs_dt=datetime.datetime(
+                recent_date.year, recent_date.month, recent_date.day, 8, 0
+            )
+        )
+        _insert_pending_provisional(HOTSPOT_ID, obs, "year", YEAR)
+        _insert_species(HOTSPOT_ID, YEAR, obs)
+
+        with patch(
+            "cloaca.piper.year_lifers.fetch_observations_for_date",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            confirmed, invalidated = await check_pending_provisionals(
+                HOTSPOT_ID, []
+            )
+
+        assert confirmed == []
+        assert invalidated == []
+        # Still pending
+        assert len(_get_pending_provisionals(HOTSPOT_ID)) == 1
+
+    @pytest.mark.asyncio
+    async def test_fetches_extra_dates_for_old_pending(self):
+        """Pending from an older date triggers an extra API call for that
+        date rather than relying on today/yesterday only."""
+        old_date = datetime.date.today() - datetime.timedelta(days=5)
+        obs = make_obs(
+            obs_dt=datetime.datetime(
+                old_date.year, old_date.month, old_date.day, 8, 0
+            )
+        )
+        _insert_pending_provisional(HOTSPOT_ID, obs, "year", YEAR)
+        _insert_species(HOTSPOT_ID, YEAR, obs)
+
+        reviewed = make_obs(
+            obs_reviewed=True,
+            obs_dt=datetime.datetime(
+                old_date.year, old_date.month, old_date.day, 8, 0
+            ),
+        )
+
+        with patch(
+            "cloaca.piper.year_lifers.fetch_observations_for_date",
+            new_callable=AsyncMock,
+            return_value=[reviewed],
+        ) as mock_fetch:
+            confirmed, invalidated = await check_pending_provisionals(
+                HOTSPOT_ID, []  # no recent observations
+            )
+
+        mock_fetch.assert_called_once_with(HOTSPOT_ID, old_date)
+        assert len(confirmed) == 1
+
+
+# ---------------------------------------------------------------------------
+# Formatting: year lifer messages
+# ---------------------------------------------------------------------------
+
+
+class TestFormatYearLiferMessage:
+    def test_single(self):
+        obs = make_obs(checklist_id="S999")
+        msg = format_year_lifer_message([obs], "Franz Sigel Park", 42)
+        assert "Year Bird #42" in msg
+        assert "Franz Sigel Park" in msg
+        assert "Yellow-throated Warbler" in msg
+        assert "Jane Doe" in msg
+        assert "S999" in msg
+
+    def test_multiple(self):
+        obs1 = make_obs("amrob", "American Robin")
+        obs2 = make_obs("yetwar", "Yellow-throated Warbler")
+        msg = format_year_lifer_message([obs1, obs2], "Franz Sigel Park", 42)
+        assert "2 New Year Birds" in msg
+        assert "42 species" in msg
+        assert "American Robin" in msg
+        assert "Yellow-throated Warbler" in msg
+
+
+class TestFormatAllTimeLiferMessage:
+    def test_single(self):
+        obs = make_obs()
+        msg = format_all_time_lifer_message([obs], "Franz Sigel Park", 100)
+        assert "New Park Bird" in msg
+        assert "#100 all-time" in msg
+        assert "Yellow-throated Warbler" in msg
+
+    def test_multiple(self):
+        obs1 = make_obs("amrob", "American Robin")
+        obs2 = make_obs("yetwar", "Yellow-throated Warbler")
+        msg = format_all_time_lifer_message(
+            [obs1, obs2], "Franz Sigel Park", 100
+        )
+        assert "2 New Park Birds" in msg
+        assert "100 species all-time" in msg
+
+
+# ---------------------------------------------------------------------------
+# Formatting: tentative messages
+# ---------------------------------------------------------------------------
+
+
+class TestFormatTentativeMessages:
+    def test_tentative_year_single(self):
+        obs = make_obs(checklist_id="S999")
+        msg = format_tentative_year_lifer_message([obs], "Franz Sigel Park")
+        assert "Possible Year Bird" in msg
+        assert "Yellow-throated Warbler" in msg
+        assert "Awaiting eBird review" in msg
+        assert "S999" in msg
+
+    def test_tentative_year_multiple(self):
+        obs1 = make_obs("amrob", "American Robin")
+        obs2 = make_obs("yetwar", "Yellow-throated Warbler")
+        msg = format_tentative_year_lifer_message(
+            [obs1, obs2], "Franz Sigel Park"
+        )
+        assert "2 Possible New Year Birds" in msg
+        assert "Awaiting eBird review" in msg
+
+    def test_tentative_all_time_single(self):
+        obs = make_obs()
+        msg = format_tentative_all_time_lifer_message(
+            [obs], "Franz Sigel Park"
+        )
+        assert "Possible New Park Bird" in msg
+        assert "Yellow-throated Warbler" in msg
+        assert "Awaiting eBird review" in msg
+
+    def test_tentative_all_time_multiple(self):
+        obs1 = make_obs("amrob", "American Robin")
+        obs2 = make_obs("yetwar", "Yellow-throated Warbler")
+        msg = format_tentative_all_time_lifer_message(
+            [obs1, obs2], "Franz Sigel Park"
+        )
+        assert "2 Possible New Park Birds" in msg
+
+
+# ---------------------------------------------------------------------------
+# Formatting: confirmed messages
+# ---------------------------------------------------------------------------
+
+
+class TestFormatConfirmedMessages:
+    def _pending(self, **kwargs):
+        defaults = dict(
+            hotspot_id=HOTSPOT_ID,
+            species_code="yetwar",
+            common_name="Yellow-throated Warbler",
+            scientific_name="Setophaga dominica",
+            obs_date=datetime.date(2026, 4, 11),
+            observer_name="Jane Doe",
+            checklist_id="S999",
+            lifer_type="year",
+            year=YEAR,
+        )
+        defaults.update(kwargs)
+        return PendingProvisional(**defaults)
+
+    def test_confirmed_year_single(self):
+        p = self._pending()
+        msg = format_confirmed_year_lifer_message(
+            [p], "Franz Sigel Park", 42
+        )
+        assert "Confirmed!" in msg
+        assert "Year Bird #42" in msg
+        assert "Yellow-throated Warbler" in msg
+        assert "reviewed and confirmed" in msg
+
+    def test_confirmed_year_multiple(self):
+        p1 = self._pending(species_code="amrob", common_name="American Robin")
+        p2 = self._pending()
+        msg = format_confirmed_year_lifer_message(
+            [p1, p2], "Franz Sigel Park", 42
+        )
+        assert "2 Year Birds Confirmed" in msg
+        assert "42 species" in msg
+
+    def test_confirmed_all_time_single(self):
+        p = self._pending(lifer_type="all_time")
+        msg = format_confirmed_all_time_lifer_message(
+            [p], "Franz Sigel Park", 100
+        )
+        assert "Confirmed!" in msg
+        assert "New Park Bird" in msg
+        assert "#100 all-time" in msg
+
+    def test_confirmed_all_time_multiple(self):
+        p1 = self._pending(
+            species_code="amrob",
+            common_name="American Robin",
+            lifer_type="all_time",
+        )
+        p2 = self._pending(lifer_type="all_time")
+        msg = format_confirmed_all_time_lifer_message(
+            [p1, p2], "Franz Sigel Park", 100
+        )
+        assert "2 New Park Birds Confirmed" in msg
+
+
+# ---------------------------------------------------------------------------
+# Formatting: invalidated message
+# ---------------------------------------------------------------------------
+
+
+class TestFormatInvalidatedMessage:
+    def test_single(self):
+        p = PendingProvisional(
+            hotspot_id=HOTSPOT_ID,
+            species_code="yetwar",
+            common_name="Yellow-throated Warbler",
+            scientific_name="Setophaga dominica",
+            obs_date=datetime.date(2026, 4, 11),
+            observer_name="Jane Doe",
+            checklist_id="S999",
+            lifer_type="year",
+            year=YEAR,
+        )
+        msg = format_invalidated_lifer_message([p], "Franz Sigel Park")
+        assert "Yellow-throated Warbler" in msg
+        assert "not confirmed" in msg
+        assert "was not" in msg
+
+    def test_multiple(self):
+        p1 = PendingProvisional(
+            hotspot_id=HOTSPOT_ID,
+            species_code="amrob",
+            common_name="American Robin",
+            scientific_name="Turdus migratorius",
+            obs_date=datetime.date(2026, 4, 11),
+            observer_name="Jane Doe",
+            checklist_id="S998",
+            lifer_type="year",
+            year=YEAR,
+        )
+        p2 = PendingProvisional(
+            hotspot_id=HOTSPOT_ID,
+            species_code="yetwar",
+            common_name="Yellow-throated Warbler",
+            scientific_name="Setophaga dominica",
+            obs_date=datetime.date(2026, 4, 11),
+            observer_name="Jane Doe",
+            checklist_id="S999",
+            lifer_type="year",
+            year=YEAR,
+        )
+        msg = format_invalidated_lifer_message([p1, p2], "Franz Sigel Park")
+        assert "were not confirmed" in msg


### PR DESCRIPTION
## Summary
This PR adds support for tracking unreviewed (provisional) bird observations and monitoring them for eBird review confirmation. Previously, all new lifers were treated as confirmed immediately. Now the system distinguishes between confirmed (reviewed) and provisional (unreviewed) observations, tracks provisional ones in a database, and sends follow-up alerts when they're confirmed or invalidated.

## Key Changes

- **New `PendingProvisional` dataclass**: Stores metadata about provisional observations awaiting eBird review, including observation date, observer name, checklist ID, and lifer type (year/all-time).

- **New database table `pending_provisional_lifers`**: Persists provisional observations with a composite primary key on (hotspot_id, species_code, lifer_type) to prevent duplicate tracking.

- **Observation splitting logic**: Added `_split_confirmed_provisional()` to categorize new lifers based on whether ANY observation of that species has been reviewed by eBird (not just the earliest one).

- **Return type changes**: `check_for_new_year_lifers()` and `check_for_new_all_time_lifers()` now return tuples of (confirmed, provisional) instead of a single list.

- **Provisional review monitoring**: New `check_pending_provisionals()` function that:
  - Fetches pending provisional observations from the database
  - Issues extra API calls for observations outside the normal 2-day poll window
  - Detects confirmed observations (now have `obsReviewed=True`)
  - Detects invalidated observations (missing from API for 14+ days)
  - Updates the database accordingly

- **New message formatters**: Added separate formatting functions for:
  - Tentative (unreviewed) alerts: `format_tentative_year_lifer_message()`, `format_tentative_all_time_lifer_message()`
  - Confirmed (after review) alerts: `format_confirmed_year_lifer_message()`, `format_confirmed_all_time_lifer_message()`
  - Invalidation notices: `format_invalidated_lifer_message()`

- **API enhancement**: Added `include_provisional=True` parameter to observation fetches to ensure provisional records are included.

- **Database cleanup functions**: Added `_remove_pending_provisional()`, `_remove_year_species()`, and `_remove_all_time_species()` to manage state transitions.

- **Updated main polling loop**: Now handles three stages:
  1. Detect new lifers (confirmed + provisional)
  2. Send appropriate alerts for each
  3. Check previously-pending provisionals for review status changes

## Implementation Details

- Provisional observations are inserted into the known species set immediately (to prevent re-alerting) but tracked separately for follow-up.
- If a provisional observation is invalidated, it's removed from the known species set so a future valid observation can trigger a fresh alert.
- The 14-day stale threshold for invalidation assumes that if an observation hasn't reappeared in the API after that time, it was rejected or the checklist was deleted.
- Confirmed observations are detected by the presence of `obsReviewed=True` in any matching observation from eBird's API (which only returns valid records).

https://claude.ai/code/session_012J6jHhYXcSrXABaCAsamLA