### PR TITLE
Fix checklist URLs and convert to Discord buttons

### DIFF
--- a/src/cloaca/piper/main.py
+++ b/src/cloaca/piper/main.py
@@ -22,6 +22,7 @@ from cloaca.piper.year_lifers import (
     check_for_new_all_time_lifers,
     check_for_new_year_lifers,
     check_pending_provisionals,
+    checklist_link_view,
     fetch_recent_observations,
     format_all_time_lifer_message,
     format_confirmed_all_time_lifer_message,
@@ -154,7 +155,12 @@ async def check_year_lifers():
             message = format_tentative_all_time_lifer_message(
                 provisional_at, hotspot.name
             )
-            await channel.send(message, view=all_time_list_link_view(hotspot.id))
+            await channel.send(
+                message,
+                view=checklist_link_view(
+                    [(o.comName, o.subId) for o in provisional_at]
+                ),
+            )
             logger.info(
                 "posted %d tentative all-time lifer(s) for %s",
                 len(provisional_at),
@@ -188,7 +194,12 @@ async def check_year_lifers():
 
         if provisional_yr:
             message = format_tentative_year_lifer_message(provisional_yr, hotspot.name)
-            await channel.send(message, view=year_list_link_view(hotspot.id))
+            await channel.send(
+                message,
+                view=checklist_link_view(
+                    [(o.comName, o.subId) for o in provisional_yr]
+                ),
+            )
             logger.info(
                 "posted %d tentative year lifer(s) for %s",
                 len(provisional_yr),
@@ -215,13 +226,23 @@ async def check_year_lifers():
                 message = format_confirmed_all_time_lifer_message(
                     at_confirmed, hotspot.name, total
                 )
-                await channel.send(message, view=all_time_list_link_view(hotspot.id))
+                await channel.send(
+                    message,
+                    view=checklist_link_view(
+                        [(p.common_name, p.sub_id) for p in at_confirmed]
+                    ),
+                )
             if yr_confirmed:
                 total = get_year_total(hotspot.id)
                 message = format_confirmed_year_lifer_message(
                     yr_confirmed, hotspot.name, total
                 )
-                await channel.send(message, view=year_list_link_view(hotspot.id))
+                await channel.send(
+                    message,
+                    view=checklist_link_view(
+                        [(p.common_name, p.sub_id) for p in yr_confirmed]
+                    ),
+                )
 
         if pend_invalidated:
             message = format_invalidated_lifer_message(pend_invalidated, hotspot.name)

--- a/src/cloaca/piper/year_lifers.py
+++ b/src/cloaca/piper/year_lifers.py
@@ -34,7 +34,7 @@ class PendingProvisional:
     scientific_name: str
     obs_date: datetime.date
     observer_name: str
-    checklist_id: str
+    sub_id: str
     lifer_type: str  # 'year' or 'all_time'
     year: int | None  # set for year lifers
     created_at: datetime.datetime | None = None
@@ -105,7 +105,7 @@ def _ensure_tables(con: duckdb.DuckDBPyConnection):
             scientific_name VARCHAR NOT NULL,
             obs_date DATE NOT NULL,
             observer_name VARCHAR NOT NULL,
-            checklist_id VARCHAR NOT NULL,
+            sub_id VARCHAR NOT NULL,
             lifer_type VARCHAR NOT NULL,
             year INTEGER,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -206,7 +206,7 @@ def _get_pending_provisionals(hotspot_id: str) -> list[PendingProvisional]:
         get_state_db()
         .execute(
             """SELECT hotspot_id, species_code, common_name, scientific_name,
-                      obs_date, observer_name, checklist_id, lifer_type, year,
+                      obs_date, observer_name, sub_id, lifer_type, year,
                       created_at
                FROM pending_provisional_lifers
                WHERE hotspot_id = ?""",
@@ -222,7 +222,7 @@ def _get_pending_provisionals(hotspot_id: str) -> list[PendingProvisional]:
             scientific_name=r[3],
             obs_date=r[4].date() if isinstance(r[4], datetime.datetime) else r[4],
             observer_name=r[5],
-            checklist_id=r[6],
+            sub_id=r[6],
             lifer_type=r[7],
             year=r[8],
             created_at=r[9],
@@ -240,7 +240,7 @@ def _insert_pending_provisional(
     get_state_db().execute(
         """INSERT INTO pending_provisional_lifers
            (hotspot_id, species_code, common_name, scientific_name,
-            obs_date, observer_name, checklist_id, lifer_type, year)
+            obs_date, observer_name, sub_id, lifer_type, year)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
            ON CONFLICT DO NOTHING""",
         [
@@ -250,7 +250,7 @@ def _insert_pending_provisional(
             obs.sciName,
             obs.obsDt.date(),
             obs.userDisplayName,
-            obs.checklistId,
+            obs.subId,
             lifer_type,
             year,
         ],
@@ -666,7 +666,7 @@ def format_year_lifer_message(
         obs = new_lifers[0]
         date_str = obs.obsDt.strftime("%b %-d")
         header = f"{birds[0]} **Year Bird #{year_total} for {hotspot_name}!**"
-        checklist_url = f"https://ebird.org/checklist/{obs.checklistId}"
+        checklist_url = f"https://ebird.org/checklist/{obs.subId}"
         body = (
             f"**{obs.comName}** — first spotted by "
             f"{obs.userDisplayName} ({date_str})\n"
@@ -682,7 +682,7 @@ def format_year_lifer_message(
     lines = [header, ""]
     for obs in new_lifers:
         date_str = obs.obsDt.strftime("%b %-d")
-        checklist_url = f"https://ebird.org/checklist/{obs.checklistId}"
+        checklist_url = f"https://ebird.org/checklist/{obs.subId}"
         lines.append(
             f"**{obs.comName}** — {obs.userDisplayName} "
             f"({date_str}) · [checklist]({checklist_url})"
@@ -701,7 +701,7 @@ def format_all_time_lifer_message(
         header = (
             f"🎉🥳 **New Park Bird for {hotspot_name}!** (#{all_time_total} all-time)"
         )
-        checklist_url = f"https://ebird.org/checklist/{obs.checklistId}"
+        checklist_url = f"https://ebird.org/checklist/{obs.subId}"
         body = (
             f"**{obs.comName}** — first spotted by "
             f"{obs.userDisplayName} ({date_str})\n"
@@ -716,7 +716,7 @@ def format_all_time_lifer_message(
     lines = [header, ""]
     for obs in new_lifers:
         date_str = obs.obsDt.strftime("%b %-d")
-        checklist_url = f"https://ebird.org/checklist/{obs.checklistId}"
+        checklist_url = f"https://ebird.org/checklist/{obs.subId}"
         lines.append(
             f"**{obs.comName}** — {obs.userDisplayName} "
             f"({date_str}) · [checklist]({checklist_url})"
@@ -734,12 +734,10 @@ def format_tentative_year_lifer_message(
     if len(new_lifers) == 1:
         obs = new_lifers[0]
         date_str = obs.obsDt.strftime("%b %-d")
-        checklist_url = f"https://ebird.org/checklist/{obs.checklistId}"
         return (
             f"👀 **Possible Year Bird for {hotspot_name}!**\n\n"
             f"**{obs.comName}** — reported by "
             f"{obs.userDisplayName} ({date_str})\n"
-            f"[View checklist]({checklist_url})\n"
             "-# Awaiting eBird review — we'll celebrate once confirmed!"
         )
 
@@ -749,11 +747,7 @@ def format_tentative_year_lifer_message(
     ]
     for obs in new_lifers:
         date_str = obs.obsDt.strftime("%b %-d")
-        checklist_url = f"https://ebird.org/checklist/{obs.checklistId}"
-        lines.append(
-            f"**{obs.comName}** — {obs.userDisplayName} "
-            f"({date_str}) · [checklist]({checklist_url})"
-        )
+        lines.append(f"**{obs.comName}** — {obs.userDisplayName} ({date_str})")
     lines.append("-# Awaiting eBird review — we'll celebrate once confirmed!")
     return "\n".join(lines)
 
@@ -765,12 +759,10 @@ def format_tentative_all_time_lifer_message(
     if len(new_lifers) == 1:
         obs = new_lifers[0]
         date_str = obs.obsDt.strftime("%b %-d")
-        checklist_url = f"https://ebird.org/checklist/{obs.checklistId}"
         return (
             f"👀 **Possible New Park Bird for {hotspot_name}!**\n\n"
             f"**{obs.comName}** — reported by "
             f"{obs.userDisplayName} ({date_str})\n"
-            f"[View checklist]({checklist_url})\n"
             "-# Awaiting eBird review — we'll celebrate once confirmed!"
         )
 
@@ -780,11 +772,7 @@ def format_tentative_all_time_lifer_message(
     ]
     for obs in new_lifers:
         date_str = obs.obsDt.strftime("%b %-d")
-        checklist_url = f"https://ebird.org/checklist/{obs.checklistId}"
-        lines.append(
-            f"**{obs.comName}** — {obs.userDisplayName} "
-            f"({date_str}) · [checklist]({checklist_url})"
-        )
+        lines.append(f"**{obs.comName}** — {obs.userDisplayName} ({date_str})")
     lines.append("-# Awaiting eBird review — we'll celebrate once confirmed!")
     return "\n".join(lines)
 
@@ -801,12 +789,10 @@ def format_confirmed_year_lifer_message(
 
     if len(confirmed) == 1:
         p = confirmed[0]
-        checklist_url = f"https://ebird.org/checklist/{p.checklist_id}"
         return (
             f"{birds[0]} **Confirmed! Year Bird #{year_total} "
             f"for {hotspot_name}!**\n\n"
-            f"**{p.common_name}** has been reviewed and confirmed on eBird!\n"
-            f"[View checklist]({checklist_url})"
+            f"**{p.common_name}** has been reviewed and confirmed on eBird!"
         )
 
     header = (
@@ -815,8 +801,7 @@ def format_confirmed_year_lifer_message(
     )
     lines = [header, ""]
     for p in confirmed:
-        checklist_url = f"https://ebird.org/checklist/{p.checklist_id}"
-        lines.append(f"**{p.common_name}** — confirmed! · [checklist]({checklist_url})")
+        lines.append(f"**{p.common_name}** — confirmed!")
     return "\n".join(lines)
 
 
@@ -827,12 +812,10 @@ def format_confirmed_all_time_lifer_message(
 ) -> str:
     if len(confirmed) == 1:
         p = confirmed[0]
-        checklist_url = f"https://ebird.org/checklist/{p.checklist_id}"
         return (
             f"🎉🥳 **Confirmed! New Park Bird for {hotspot_name}!** "
             f"(#{all_time_total} all-time)\n\n"
-            f"**{p.common_name}** has been reviewed and confirmed on eBird!\n"
-            f"[View checklist]({checklist_url})"
+            f"**{p.common_name}** has been reviewed and confirmed on eBird!"
         )
 
     header = (
@@ -841,8 +824,7 @@ def format_confirmed_all_time_lifer_message(
     )
     lines = [header, ""]
     for p in confirmed:
-        checklist_url = f"https://ebird.org/checklist/{p.checklist_id}"
-        lines.append(f"**{p.common_name}** — confirmed! · [checklist]({checklist_url})")
+        lines.append(f"**{p.common_name}** — confirmed!")
     return "\n".join(lines)
 
 
@@ -859,6 +841,35 @@ def format_invalidated_lifer_message(
     return (
         f"**Update:** {names} at {hotspot_name} were not confirmed after eBird review."
     )
+
+
+def checklist_link_view(
+    checklists: list[tuple[str, str]],
+) -> discord.ui.View:
+    """Button view linking to one or more eBird checklists.
+
+    *checklists* is a list of ``(species_name, sub_id)`` tuples.
+    """
+    view = discord.ui.View()
+    if len(checklists) == 1:
+        _, sub_id = checklists[0]
+        view.add_item(
+            discord.ui.Button(
+                style=discord.ButtonStyle.link,
+                label="View Checklist on eBird",
+                url=f"https://ebird.org/checklist/{sub_id}",
+            )
+        )
+    else:
+        for name, sub_id in checklists:
+            view.add_item(
+                discord.ui.Button(
+                    style=discord.ButtonStyle.link,
+                    label=f"{name} checklist",
+                    url=f"https://ebird.org/checklist/{sub_id}",
+                )
+            )
+    return view
 
 
 def all_time_list_link_view(hotspot_id: str) -> discord.ui.View:

--- a/tests/piper/test_main.py
+++ b/tests/piper/test_main.py
@@ -70,7 +70,7 @@ def make_pending(
         scientific_name="Setophaga dominica",
         obs_date=datetime.date(2026, 4, 11),
         observer_name="Jane Doe",
-        checklist_id="S100001",
+        sub_id="S100001",
         lifer_type=lifer_type,
         year=2026 if lifer_type == "year" else None,
     )
@@ -113,6 +113,7 @@ def patches(mock_channel):
         format_invalidated_lifer_message=MagicMock(return_value="INVAL_MSG"),
         all_time_list_link_view=MagicMock(return_value=None),
         year_list_link_view=MagicMock(return_value=None),
+        checklist_link_view=MagicMock(return_value=None),
     )
     with p as patched:
         mocks.update(patched)
@@ -149,6 +150,7 @@ async def _run_check(mock_channel, **overrides):
         format_invalidated_lifer_message=MagicMock(return_value="INVAL_MSG"),
         all_time_list_link_view=MagicMock(return_value=None),
         year_list_link_view=MagicMock(return_value=None),
+        checklist_link_view=MagicMock(return_value=None),
     )
     default_mocks.update(overrides)
 

--- a/tests/piper/test_year_lifers.py
+++ b/tests/piper/test_year_lifers.py
@@ -48,6 +48,7 @@ def make_obs(
     sci_name: str = "Setophaga dominica",
     obs_dt: datetime.datetime | None = None,
     checklist_id: str = "S100001",
+    sub_id: str = "S100001",
     user_display_name: str = "Jane Doe",
     obs_reviewed: bool = False,
     obs_valid: bool = True,
@@ -67,7 +68,7 @@ def make_obs(
         obsValid=obs_valid,
         obsReviewed=obs_reviewed,
         locationPrivate=False,
-        subId="S100001",
+        subId=sub_id,
         subnational2Code="US-NY-005",
         subnational2Name="Bronx",
         subnational1Code="US-NY",
@@ -528,7 +529,7 @@ class TestCheckPendingProvisionals:
 
 class TestFormatYearLiferMessage:
     def test_single(self):
-        obs = make_obs(checklist_id="S999")
+        obs = make_obs(sub_id="S999")
         msg = format_year_lifer_message([obs], "Franz Sigel Park", 42)
         assert "Year Bird #42" in msg
         assert "Franz Sigel Park" in msg
@@ -569,12 +570,11 @@ class TestFormatAllTimeLiferMessage:
 
 class TestFormatTentativeMessages:
     def test_tentative_year_single(self):
-        obs = make_obs(checklist_id="S999")
+        obs = make_obs()
         msg = format_tentative_year_lifer_message([obs], "Franz Sigel Park")
         assert "Possible Year Bird" in msg
         assert "Yellow-throated Warbler" in msg
         assert "Awaiting eBird review" in msg
-        assert "S999" in msg
 
     def test_tentative_year_multiple(self):
         obs1 = make_obs("amrob", "American Robin")
@@ -611,7 +611,7 @@ class TestFormatConfirmedMessages:
             scientific_name="Setophaga dominica",
             obs_date=datetime.date(2026, 4, 11),
             observer_name="Jane Doe",
-            checklist_id="S999",
+            sub_id="S999",
             lifer_type="year",
             year=YEAR,
         )
@@ -665,7 +665,7 @@ class TestFormatInvalidatedMessage:
             scientific_name="Setophaga dominica",
             obs_date=datetime.date(2026, 4, 11),
             observer_name="Jane Doe",
-            checklist_id="S999",
+            sub_id="S999",
             lifer_type="year",
             year=YEAR,
         )
@@ -682,7 +682,7 @@ class TestFormatInvalidatedMessage:
             scientific_name="Turdus migratorius",
             obs_date=datetime.date(2026, 4, 11),
             observer_name="Jane Doe",
-            checklist_id="S998",
+            sub_id="S998",
             lifer_type="year",
             year=YEAR,
         )
@@ -693,7 +693,7 @@ class TestFormatInvalidatedMessage:
             scientific_name="Setophaga dominica",
             obs_date=datetime.date(2026, 4, 11),
             observer_name="Jane Doe",
-            checklist_id="S999",
+            sub_id="S999",
             lifer_type="year",
             year=YEAR,
         )


### PR DESCRIPTION
## Summary

- **Fix checklist URLs**: All checklist links were using `obs.checklistId` (e.g. `CL24653`) instead of `obs.subId` (e.g. `S320098462`) — the latter is what eBird actually uses in checklist URLs
- **Checklist buttons**: Tentative and confirmed follow-up messages now use Discord buttons for checklist links instead of inline markdown, matching the existing button pattern used for hotspot list links
- **Rename `PendingProvisional.checklist_id` to `sub_id`** to match what the field actually stores

## Test plan

- [x] 60 existing tests updated and passing
- [x] Ruff lint + format clean

https://claude.ai/code/session_012J6jHhYXcSrXABaCAsamLA