### PR TITLE
Poll for today's BirdCast forecast instead of single daily check

### DIFF
--- a/src/cloaca/piper/CLAUDE.md
+++ b/src/cloaca/piper/CLAUDE.md
@@ -10,7 +10,7 @@ Piper runs inside the cloaca FastAPI server as an asyncio background task (not a
 
 - `main.py` — Discord bot event handlers (`on_ready`, `on_message`), conversation cache, reply-chain context builder. Entry point is the `start()` coroutine.
 - `bird_query.py` — Core query logic. Connects to two MCP servers (eBird API via SSE, DuckDB via stdio), builds a tool-augmented Claude conversation, and streams the response. Contains the system prompt and the cached DuckDB connection pool.
-- `birdcast.py` — Daily BirdCast migration forecast. Fetches a 3-night forecast from the BirdCast API for NYC, formats a color-coded Discord message (🔵 Low, 🟡 Medium, 🔴 High), and posts to #bird-cast-updates. Scheduled via `discord.ext.tasks.loop` at 7:00 AM Eastern. Response is validated with Pydantic models (`BirdcastForecast`, `ForecastNight`).
+- `birdcast.py` — Daily BirdCast migration forecast. Fetches a 3-night forecast from the BirdCast API for NYC, formats a color-coded Discord message (🔵 Low, 🟡 Medium, 🔴 High), and posts to #bird-cast-updates. Polls every 15 minutes starting at 7:00 AM Eastern until the forecast updates for today (detected by checking if the first forecast night's date is today rather than yesterday), then stops retrying until the next day. Posts are deduplicated via the `birdcast_post_log` table. Response is validated with Pydantic models (`BirdcastForecast`, `ForecastNight`).
 - `cli.py` — Standalone CLI for testing queries without Discord: `uv run python -m cloaca.piper.cli "what warblers are in prospect park?"`
 - `year_lifers.py` — Year lifer and all-time park lifer tracking for multiple hotspots. Polls the eBird historic observations API every 15 minutes (hourly at night) to detect new species. Observations are fetched once per hotspot and checked against both the year list and all-time list. Stores state in Postgres (`DATABASE_URL`). On first run, backfills the current year day-by-day from the historic API, and backfills all-time species via the `product/spplist` endpoint (single API call per hotspot). Posts Discord notifications per hotspot channel — celebratory 🎉🥳 for all-time lifers, bird emojis for year lifers. If a species is both a year lifer and an all-time lifer, only the all-time notification is posted. Hotspots are configured via the `WATCHED_HOTSPOTS` list of `Hotspot` dataclasses. Reuses `eBirdHistoricFullObservation` from `scripts/fetch_yearly_hotspot_data.py` and `get_phoebe_client()` from `api/shared.py`.
 - `db_pool.py` — SQLAlchemy async engine management for the Postgres connection pool. Provides `get_engine()` and `close_engine()`.
@@ -55,6 +55,7 @@ To add a new hotspot, append a `Hotspot` entry to the list.
 - `hotspot_all_time_species` — all-time park species (species code only). PK: `(hotspot_id, species_code)`. Backfilled via the eBird `product/spplist` API.
 - `backfill_status` — tracks backfill completion per hotspot. PK: `(hotspot_id, year)`. Uses `year=0` as sentinel for all-time backfills.
 - `pending_provisional_lifers` — provisional observations awaiting eBird review. PK: `(hotspot_id, species_code, lifer_type)`.
+- `birdcast_post_log` — tracks which forecast dates have been posted per location, to prevent duplicate posts. PK: `(location, forecast_date)`.
 
 **Changing the schema**: Edit `sql/schema.sql` and `sql/queries.sql`, run `sqlc generate`, fix the import in `db/queries.py` (`from db import models` → `from cloaca.piper.db import models`), and create a new Alembic migration.
 
@@ -70,7 +71,7 @@ To add a new hotspot, append a `Hotspot` entry to the list.
 
 | Task | Schedule | Channel | Module |
 |------|----------|---------|--------|
-| BirdCast forecast | Daily at 7:00 AM Eastern | #bird-cast-updates | `birdcast.py` |
+| BirdCast forecast | Every 15 min, 7 AM–noon Eastern (stops after posting) | #bird-cast-updates | `birdcast.py` |
 | Lifer check (year + all-time) | Every 15 min (hourly at night) | Per hotspot (see `WATCHED_HOTSPOTS`) | `year_lifers.py` |
 
 Both are started in `on_ready()` via `discord.ext.tasks.loop`.

--- a/src/cloaca/piper/alembic/versions/002_create_birdcast_post_log.py
+++ b/src/cloaca/piper/alembic/versions/002_create_birdcast_post_log.py
@@ -1,0 +1,36 @@
+"""Create birdcast_post_log table
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-04-12
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "002"
+down_revision: Union[str, None] = "001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "birdcast_post_log",
+        sa.Column("location", sa.Text, nullable=False),
+        sa.Column("forecast_date", sa.Date, nullable=False),
+        sa.Column(
+            "posted_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("location", "forecast_date"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("birdcast_post_log")

--- a/src/cloaca/piper/birdcast.py
+++ b/src/cloaca/piper/birdcast.py
@@ -2,12 +2,19 @@ import datetime
 import logging
 import os
 import random
+from zoneinfo import ZoneInfo
 
 import aiohttp
 import discord
 from pydantic import BaseModel
 
+from cloaca.piper.db.queries import AsyncQuerier
+from cloaca.piper.db_pool import get_engine
+
 logger = logging.getLogger(__name__)
+
+EASTERN = ZoneInfo("America/New_York")
+BIRDCAST_LOCATION = "nyc"
 
 BIRDCAST_API_BASE = (
     "https://alert.birdcast.org/api/is-birdcast-alert-api"
@@ -68,6 +75,31 @@ async def fetch_birdcast_forecast() -> BirdcastForecast | None:
     except Exception:
         logger.exception("failed to parse BirdCast response")
         return None
+
+
+def is_todays_forecast(forecast: BirdcastForecast) -> bool:
+    """True if the first forecast night's date is today (Eastern time)."""
+    if not forecast.forecastNights:
+        return False
+    today = datetime.datetime.now(EASTERN).date()
+    return forecast.forecastNights[0].date.date() == today
+
+
+async def is_forecast_posted(date: datetime.date) -> bool:
+    engine = get_engine()
+    async with engine.connect() as conn:
+        q = AsyncQuerier(conn)
+        return (
+            await q.is_birdcast_posted(location=BIRDCAST_LOCATION, forecast_date=date)
+            is not None
+        )
+
+
+async def mark_forecast_posted(date: datetime.date) -> None:
+    engine = get_engine()
+    async with engine.begin() as conn:
+        q = AsyncQuerier(conn)
+        await q.insert_birdcast_post(location=BIRDCAST_LOCATION, forecast_date=date)
 
 
 def format_forecast_message(forecast: BirdcastForecast) -> str:

--- a/src/cloaca/piper/db/models.py
+++ b/src/cloaca/piper/db/models.py
@@ -13,6 +13,12 @@ class BackfillStatus(pydantic.BaseModel):
     species_count: int
 
 
+class BirdcastPostLog(pydantic.BaseModel):
+    location: str
+    forecast_date: datetime.date
+    posted_at: datetime.datetime
+
+
 class HotspotAllTimeSpecy(pydantic.BaseModel):
     hotspot_id: str
     species_code: str

--- a/src/cloaca/piper/db/queries.py
+++ b/src/cloaca/piper/db/queries.py
@@ -51,6 +51,13 @@ ON CONFLICT DO NOTHING
 """
 
 
+INSERT_BIRDCAST_POST = """-- name: insert_birdcast_post \\:exec
+INSERT INTO birdcast_post_log (location, forecast_date)
+VALUES (:p1, :p2)
+ON CONFLICT DO NOTHING
+"""
+
+
 INSERT_PENDING_PROVISIONAL = """-- name: insert_pending_provisional \\:exec
 INSERT INTO pending_provisional_lifers
     (hotspot_id, species_code, common_name, scientific_name,
@@ -95,6 +102,12 @@ class InsertSpeciesParams(pydantic.BaseModel):
 IS_BACKFILL_COMPLETE = """-- name: is_backfill_complete \\:one
 SELECT 1 FROM backfill_status
 WHERE hotspot_id = :p1 AND year = :p2
+"""
+
+
+IS_BIRDCAST_POSTED = """-- name: is_birdcast_posted \\:one
+SELECT 1 FROM birdcast_post_log
+WHERE location = :p1 AND forecast_date = :p2
 """
 
 
@@ -193,6 +206,13 @@ class AsyncQuerier:
             {"p1": hotspot_id, "p2": species_code},
         )
 
+    async def insert_birdcast_post(
+        self, *, location: str, forecast_date: datetime.date
+    ) -> None:
+        await self._conn.execute(
+            sqlalchemy.text(INSERT_BIRDCAST_POST), {"p1": location, "p2": forecast_date}
+        )
+
     async def insert_pending_provisional(
         self, arg: InsertPendingProvisionalParams
     ) -> None:
@@ -232,6 +252,19 @@ class AsyncQuerier:
         row = (
             await self._conn.execute(
                 sqlalchemy.text(IS_BACKFILL_COMPLETE), {"p1": hotspot_id, "p2": year}
+            )
+        ).first()
+        if row is None:
+            return None
+        return row[0]
+
+    async def is_birdcast_posted(
+        self, *, location: str, forecast_date: datetime.date
+    ) -> Optional[int]:
+        row = (
+            await self._conn.execute(
+                sqlalchemy.text(IS_BIRDCAST_POSTED),
+                {"p1": location, "p2": forecast_date},
             )
         ).first()
         if row is None:

--- a/src/cloaca/piper/main.py
+++ b/src/cloaca/piper/main.py
@@ -284,16 +284,16 @@ async def post_birdcast_forecast():
     now = datetime.datetime.now(_EASTERN)
     if now.hour < 7 or now.hour >= 12:
         return
+    today = now.date()
+    if await is_forecast_posted(today):
+        logger.info("birdcast forecast already posted for %s", today)
+        return
     forecast = await fetch_birdcast_forecast()
     if forecast is None or not forecast.forecastNights:
         logger.info("no birdcast forecast available, skipping")
         return
     if not is_todays_forecast(forecast):
         logger.info("birdcast forecast not yet updated for today, will retry")
-        return
-    today = now.date()
-    if await is_forecast_posted(today):
-        logger.info("birdcast forecast already posted for %s", today)
         return
     channel = bot.get_channel(BIRDCAST_CHANNEL_ID)
     if channel is None:

--- a/src/cloaca/piper/main.py
+++ b/src/cloaca/piper/main.py
@@ -13,6 +13,9 @@ from cloaca.piper.birdcast import (
     birdcast_link_view,
     fetch_birdcast_forecast,
     format_forecast_message,
+    is_forecast_posted,
+    is_todays_forecast,
+    mark_forecast_posted,
 )
 from cloaca.piper.year_lifers import (
     WATCHED_HOTSPOTS,
@@ -276,19 +279,30 @@ async def check_year_lifers():
             logger.info("no new lifers at %s", hotspot.name)
 
 
-@tasks.loop(time=datetime.time(hour=7, minute=0, tzinfo=_EASTERN))
+@tasks.loop(minutes=15)
 async def post_birdcast_forecast():
-    channel = bot.get_channel(BIRDCAST_CHANNEL_ID)
-    if channel is None:
-        logger.warning("could not find birdcast channel %d", BIRDCAST_CHANNEL_ID)
+    now = datetime.datetime.now(_EASTERN)
+    if now.hour < 7 or now.hour >= 12:
         return
     forecast = await fetch_birdcast_forecast()
     if forecast is None or not forecast.forecastNights:
         logger.info("no birdcast forecast available, skipping")
         return
+    if not is_todays_forecast(forecast):
+        logger.info("birdcast forecast not yet updated for today, will retry")
+        return
+    today = now.date()
+    if await is_forecast_posted(today):
+        logger.info("birdcast forecast already posted for %s", today)
+        return
+    channel = bot.get_channel(BIRDCAST_CHANNEL_ID)
+    if channel is None:
+        logger.warning("could not find birdcast channel %d", BIRDCAST_CHANNEL_ID)
+        return
     message = format_forecast_message(forecast)
     await channel.send(message, view=birdcast_link_view())
-    logger.info("posted birdcast forecast")
+    await mark_forecast_posted(today)
+    logger.info("posted birdcast forecast for %s", today)
 
 
 @bot.event

--- a/src/cloaca/piper/sql/queries.sql
+++ b/src/cloaca/piper/sql/queries.sql
@@ -59,3 +59,12 @@ WHERE hotspot_id = $1 AND year = $2 AND species_code = $3;
 -- name: RemoveAllTimeSpecies :exec
 DELETE FROM hotspot_all_time_species
 WHERE hotspot_id = $1 AND species_code = $2;
+
+-- name: IsBirdcastPosted :one
+SELECT 1 FROM birdcast_post_log
+WHERE location = $1 AND forecast_date = $2;
+
+-- name: InsertBirdcastPost :exec
+INSERT INTO birdcast_post_log (location, forecast_date)
+VALUES ($1, $2)
+ON CONFLICT DO NOTHING;

--- a/src/cloaca/piper/sql/schema.sql
+++ b/src/cloaca/piper/sql/schema.sql
@@ -38,3 +38,10 @@ CREATE TABLE pending_provisional_lifers (
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (hotspot_id, species_code, lifer_type)
 );
+
+CREATE TABLE birdcast_post_log (
+    location TEXT NOT NULL,
+    forecast_date DATE NOT NULL,
+    posted_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (location, forecast_date)
+);

--- a/tests/piper/conftest.py
+++ b/tests/piper/conftest.py
@@ -58,6 +58,7 @@ async def state_db(pg_url, monkeypatch):
     # Drop and recreate tables for full isolation
     async with engine.begin() as conn:
         for table in [
+            "birdcast_post_log",
             "pending_provisional_lifers",
             "hotspot_all_time_species",
             "backfill_status",

--- a/tests/piper/test_birdcast.py
+++ b/tests/piper/test_birdcast.py
@@ -1,0 +1,245 @@
+"""Tests for piper birdcast forecast polling and posting."""
+
+import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from cloaca.piper.birdcast import (
+    BirdcastForecast,
+    ForecastNight,
+    format_forecast_message,
+    is_forecast_posted,
+    is_todays_forecast,
+    mark_forecast_posted,
+)
+
+EASTERN = ZoneInfo("America/New_York")
+MODULE = "cloaca.piper.main"
+BIRDCAST_MODULE = "cloaca.piper.birdcast"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_forecast(
+    *,
+    first_date: datetime.datetime | None = None,
+    nights: int = 3,
+) -> BirdcastForecast:
+    """Build a BirdcastForecast with `nights` consecutive nights starting at first_date."""
+    if first_date is None:
+        first_date = datetime.datetime.now(EASTERN).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+    forecast_nights = []
+    for i in range(nights):
+        forecast_nights.append(
+            ForecastNight(
+                date=first_date + datetime.timedelta(days=i),
+                total=1000 * (i + 1),
+                code=i + 1,
+            )
+        )
+    return BirdcastForecast(
+        generatedDate=first_date,
+        forecastNights=forecast_nights,
+    )
+
+
+# ---------------------------------------------------------------------------
+# is_todays_forecast (pure function)
+# ---------------------------------------------------------------------------
+
+
+class TestIsTodaysForecast:
+    def test_true_when_first_night_is_today(self):
+        now = datetime.datetime.now(EASTERN)
+        today = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        forecast = make_forecast(first_date=today)
+        assert is_todays_forecast(forecast) is True
+
+    def test_false_when_first_night_is_yesterday(self):
+        now = datetime.datetime.now(EASTERN)
+        yesterday = (now - datetime.timedelta(days=1)).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        forecast = make_forecast(first_date=yesterday)
+        assert is_todays_forecast(forecast) is False
+
+    def test_false_when_no_nights(self):
+        forecast = BirdcastForecast(
+            generatedDate=datetime.datetime.now(EASTERN),
+            forecastNights=[],
+        )
+        assert is_todays_forecast(forecast) is False
+
+
+# ---------------------------------------------------------------------------
+# format_forecast_message (pure function)
+# ---------------------------------------------------------------------------
+
+
+class TestFormatForecastMessage:
+    def test_contains_migration_update_header(self):
+        forecast = make_forecast()
+        msg = format_forecast_message(forecast)
+        assert "**Migration Update**" in msg
+
+    def test_contains_tonight_and_tomorrow(self):
+        forecast = make_forecast()
+        msg = format_forecast_message(forecast)
+        assert "Tonight" in msg
+        assert "Tomorrow" in msg
+
+    def test_three_nights_shows_weekday_for_third(self):
+        now = datetime.datetime.now(EASTERN)
+        today = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        forecast = make_forecast(first_date=today, nights=3)
+        msg = format_forecast_message(forecast)
+        day_after_tomorrow = today + datetime.timedelta(days=2)
+        weekday_name = day_after_tomorrow.strftime("%A")
+        assert weekday_name in msg
+
+    def test_tier_labels_present(self):
+        forecast = make_forecast(nights=3)
+        msg = format_forecast_message(forecast)
+        assert "Low" in msg
+        assert "Medium" in msg
+        assert "High" in msg
+
+
+# ---------------------------------------------------------------------------
+# DB helpers (is_forecast_posted / mark_forecast_posted)
+# ---------------------------------------------------------------------------
+
+
+class TestBirdcastPostLog:
+    @pytest.mark.asyncio
+    async def test_not_posted_initially(self):
+        today = datetime.date.today()
+        assert await is_forecast_posted(today) is False
+
+    @pytest.mark.asyncio
+    async def test_posted_after_mark(self):
+        today = datetime.date.today()
+        await mark_forecast_posted(today)
+        assert await is_forecast_posted(today) is True
+
+    @pytest.mark.asyncio
+    async def test_different_dates_independent(self):
+        today = datetime.date.today()
+        yesterday = today - datetime.timedelta(days=1)
+        await mark_forecast_posted(yesterday)
+        assert await is_forecast_posted(yesterday) is True
+        assert await is_forecast_posted(today) is False
+
+    @pytest.mark.asyncio
+    async def test_duplicate_mark_is_noop(self):
+        today = datetime.date.today()
+        await mark_forecast_posted(today)
+        await mark_forecast_posted(today)  # should not raise
+        assert await is_forecast_posted(today) is True
+
+
+# ---------------------------------------------------------------------------
+# post_birdcast_forecast task loop orchestration
+# ---------------------------------------------------------------------------
+
+
+async def _run_forecast(mock_channel, *, now, forecast=None):
+    """Run post_birdcast_forecast.coro() with dependencies mocked."""
+    mock_bot = MagicMock()
+    mock_bot.get_channel = MagicMock(return_value=mock_channel)
+
+    with (
+        patch(f"{MODULE}.bot", mock_bot),
+        patch(f"{MODULE}.datetime") as mock_dt,
+        patch(
+            f"{MODULE}.fetch_birdcast_forecast",
+            AsyncMock(return_value=forecast),
+        ),
+        patch(
+            f"{MODULE}.format_forecast_message",
+            MagicMock(return_value="FORECAST_MSG"),
+        ),
+        patch(f"{MODULE}.birdcast_link_view", MagicMock(return_value=None)),
+    ):
+        mock_dt.datetime.now.return_value = now
+        mock_dt.time = datetime.time
+
+        from cloaca.piper.main import post_birdcast_forecast
+
+        await post_birdcast_forecast.coro()
+
+
+class TestPostBirdcastForecast:
+    @pytest.fixture
+    def mock_channel(self):
+        ch = AsyncMock()
+        ch.send = AsyncMock()
+        return ch
+
+    @pytest.mark.asyncio
+    async def test_posts_when_fresh_and_not_yet_posted(self, mock_channel):
+        now = datetime.datetime(2026, 4, 12, 8, 0, tzinfo=EASTERN)
+        today = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        forecast = make_forecast(first_date=today)
+        await _run_forecast(mock_channel, now=now, forecast=forecast)
+        mock_channel.send.assert_called_once_with("FORECAST_MSG", view=None)
+
+    @pytest.mark.asyncio
+    async def test_skips_before_7am(self, mock_channel):
+        now = datetime.datetime(2026, 4, 12, 6, 30, tzinfo=EASTERN)
+        today = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        forecast = make_forecast(first_date=today)
+        await _run_forecast(mock_channel, now=now, forecast=forecast)
+        mock_channel.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_after_noon(self, mock_channel):
+        now = datetime.datetime(2026, 4, 12, 12, 0, tzinfo=EASTERN)
+        today = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        forecast = make_forecast(first_date=today)
+        await _run_forecast(mock_channel, now=now, forecast=forecast)
+        mock_channel.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_forecast_not_updated(self, mock_channel):
+        now = datetime.datetime(2026, 4, 12, 8, 0, tzinfo=EASTERN)
+        yesterday = now.replace(
+            hour=0, minute=0, second=0, microsecond=0
+        ) - datetime.timedelta(days=1)
+        forecast = make_forecast(first_date=yesterday)
+        await _run_forecast(mock_channel, now=now, forecast=forecast)
+        mock_channel.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_no_forecast(self, mock_channel):
+        now = datetime.datetime(2026, 4, 12, 8, 0, tzinfo=EASTERN)
+        await _run_forecast(mock_channel, now=now, forecast=None)
+        mock_channel.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_already_posted(self, mock_channel):
+        now = datetime.datetime(2026, 4, 12, 8, 0, tzinfo=EASTERN)
+        today_dt = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        forecast = make_forecast(first_date=today_dt)
+        # Post once
+        await _run_forecast(mock_channel, now=now, forecast=forecast)
+        mock_channel.send.assert_called_once()
+        mock_channel.send.reset_mock()
+        # Second run should skip
+        await _run_forecast(mock_channel, now=now, forecast=forecast)
+        mock_channel.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_records_post_in_db(self, mock_channel):
+        now = datetime.datetime(2026, 4, 12, 8, 0, tzinfo=EASTERN)
+        today_dt = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        forecast = make_forecast(first_date=today_dt)
+        await _run_forecast(mock_channel, now=now, forecast=forecast)
+        assert await is_forecast_posted(now.date()) is True


### PR DESCRIPTION
## Summary
- Instead of firing once at 7 AM and hoping the forecast is ready, poll every 15 minutes from 7 AM–noon ET until the BirdCast API returns today's forecast (first night date == today)
- New `birdcast_post_log` table (keyed on location + forecast date) prevents duplicate posts and supports future multi-city expansion
- DB check runs before the API call so we skip HTTP requests entirely once posted

## Changes
- `birdcast.py` — add `is_todays_forecast()`, `is_forecast_posted()`, `mark_forecast_posted()` helpers
- `main.py` — change `@tasks.loop(time=7am)` to `@tasks.loop(minutes=15)` with time window guard + freshness + dedup checks
- `sql/schema.sql` + `sql/queries.sql` — new `birdcast_post_log` table and queries
- `db/` — regenerated sqlc code
- Alembic migration `002_create_birdcast_post_log`
- 18 new tests covering pure functions, DB helpers, and task orchestration

## Test plan
- [x] All 82 tests pass (64 existing + 18 new)
- [x] E2E verified locally: API returns today's forecast, freshness check passes, DB dedup works
- [x] Code review and security review completed (no blocking issues)
- [ ] CI passes
- [ ] Run Alembic migration on Render Postgres after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)