### PR TITLE
Add CI/deploy monitoring scripts and shipping workflow skill

### DIFF
--- a/.claude/skills/committing-merging-and-deploying-changes.md
+++ b/.claude/skills/committing-merging-and-deploying-changes.md
@@ -1,0 +1,89 @@
+---
+name: committing-merging-and-deploying-changes
+description: Full workflow for committing changes, opening a PR, watching CI, merging, and monitoring the deploy to Render.
+---
+
+# Committing, Merging, and Deploying Changes
+
+Use this skill when the user asks to ship, merge, deploy, or go through the full commit-to-deploy workflow.
+
+## Workflow
+
+### 1. Commit
+
+- Run `git status`, `git diff`, and `git log --oneline -5` to understand the change set
+- Create a feature branch (never push directly to main)
+- Write a descriptive commit message: summary line + bullet points for what changed and why
+- Stage specific files (avoid `git add -A`)
+
+### 2. Review
+
+Run two review agents **in parallel** before pushing:
+
+- **PR code review agent** — logic correctness, edge cases, test coverage gaps
+- **Security review agent** — SQL injection, secrets, input validation, OWASP top 10, DoS vectors
+
+Address any actionable findings before proceeding.
+
+### 3. Documentation check
+
+Verify that `CLAUDE.md` and any relevant docs reflect the changes (new tables, changed schedules, new env vars, etc.).
+
+### 4. Push and open PR
+
+- Push the branch: `git push -u origin <branch-name>`
+- Open the PR with `gh pr create` including a summary, change list, and test plan
+
+### 5. Watch CI
+
+Use a **Monitor** to stream CI status:
+
+```bash
+Monitor(
+  description="CI checks on PR #<N>",
+  command="scripts/watch-ci.sh <PR_NUMBER>",
+  timeout_ms=300000,
+  persistent=false
+)
+```
+
+The script polls `gh pr checks` every 30 seconds and reports pass/fail/pending counts. It exits 0 when all checks pass, or exits 1 if any check fails.
+
+### 6. Merge
+
+Once CI passes:
+
+```bash
+gh pr merge <PR_NUMBER> --squash --delete-branch
+```
+
+### 7. Watch deploy
+
+After merging to main, Render auto-deploys. Get the merge commit SHA from `git rev-parse origin/main`, then use a **Monitor** to stream deploy status:
+
+```bash
+Monitor(
+  description="Render deploy for cloaca",
+  command="scripts/watch-deploy.sh <SERVICE_ID> <COMMIT_SHA>",
+  timeout_ms=600000,
+  persistent=false
+)
+```
+
+The script waits for a deploy matching the specific commit SHA to appear, then tracks it to completion. It exits 0 when the deploy goes live (and verifies the health check), or exits 1 on failure.
+
+### 8. Post-deploy verification
+
+After the deploy monitor reports success:
+
+- Check health: `curl -s https://cloaca.onrender.com/v1/health`
+- Tail logs: `render logs -r <SERVICE_ID> --start "$(date -u -v-5M +%Y-%m-%dT%H:%M:%SZ)" -o text --confirm`
+- If the change includes a DB migration, verify it ran: `uv run alembic -c alembic.ini history`
+
+## Important notes
+
+- Always use PRs, never push directly to main
+- Always specify branch name on `git push`
+- Look up the Render service ID from memory (reference_render_service_ids.md) — do not hardcode it in code or commits
+- `status` is a reserved variable in zsh — use `deploy_status` instead in shell scripts
+- Render suspend/resume is via API, not CLI

--- a/scripts/watch-ci.sh
+++ b/scripts/watch-ci.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Watch CI checks on a GitHub PR until they all complete.
+# Usage: scripts/watch-ci.sh [PR_NUMBER]
+#   PR_NUMBER defaults to the PR for the current branch.
+#
+# Designed to be run via Claude Code's Monitor tool so each
+# status line becomes a notification.
+
+set -euo pipefail
+
+pr="${1:-}"
+if [ -z "$pr" ]; then
+  pr=$(gh pr view --json number -q .number 2>/dev/null) || {
+    echo "ERROR: No PR number given and no PR found for current branch"
+    exit 1
+  }
+fi
+
+echo "Watching CI for PR #${pr}..."
+
+while true; do
+  # Get check status summary
+  output=$(gh pr checks "$pr" 2>&1) || true
+
+  # Count statuses
+  total=$(echo "$output" | grep -cE '(pass|fail|pending)' || true)
+  passed=$(echo "$output" | grep -c 'pass' || true)
+  failed=$(echo "$output" | grep -c 'fail' || true)
+  pending=$(echo "$output" | grep -c 'pending' || true)
+
+  echo "PR #${pr} checks: ${passed} passed, ${failed} failed, ${pending} pending (${total} total)"
+
+  if [ "$failed" -gt 0 ]; then
+    echo "CI FAILED"
+    echo "$output"
+    exit 1
+  fi
+
+  if [ "$pending" -eq 0 ] && [ "$total" -gt 0 ]; then
+    echo "CI PASSED — all ${total} checks green"
+    exit 0
+  fi
+
+  sleep 30
+done

--- a/scripts/watch-deploy.sh
+++ b/scripts/watch-deploy.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Watch a Render deploy for a specific commit until it reaches a terminal state.
+# Usage: scripts/watch-deploy.sh <SERVICE_ID> <COMMIT_SHA> [HEALTH_URL]
+#   HEALTH_URL defaults to https://cloaca.onrender.com/v1/health
+#
+# Waits for a deploy matching the given commit SHA to appear, then
+# tracks it to completion. This ensures we're watching the right
+# deploy, not a stale previous one.
+#
+# Designed to be run via Claude Code's Monitor tool so each
+# status line becomes a notification.
+
+set -euo pipefail
+
+service_id="${1:?Usage: watch-deploy.sh <SERVICE_ID> <COMMIT_SHA> [HEALTH_URL]}"
+commit_sha="${2:?Usage: watch-deploy.sh <SERVICE_ID> <COMMIT_SHA> [HEALTH_URL]}"
+health_url="${3:-https://cloaca.onrender.com/v1/health}"
+
+# Allow matching on short SHAs
+sha_len=${#commit_sha}
+
+echo "Waiting for deploy of ${commit_sha:0:12} on service ${service_id}..."
+
+while true; do
+  result=$(render deploys list "$service_id" --output json --confirm 2>/dev/null \
+    | python3 -c "
+import json, sys
+sha = '${commit_sha}'
+sha_len = ${sha_len}
+for d in json.load(sys.stdin):
+    if d.get('commit', {}).get('id', '')[:sha_len] == sha:
+        print(d['id'], d['status'])
+        sys.exit(0)
+print('not_found not_found')
+" 2>/dev/null) || result="error error"
+
+  deploy_id="${result%% *}"
+  deploy_status="${result#* }"
+
+  if [ "$deploy_id" = "not_found" ]; then
+    echo "No deploy yet for ${commit_sha:0:12}, waiting..."
+    sleep 30
+    continue
+  fi
+
+  echo "Deploy ${deploy_id}: ${deploy_status}"
+
+  case "$deploy_status" in
+    live)
+      echo "DEPLOY SUCCEEDED"
+      health=$(curl -sf "$health_url" 2>/dev/null) || health="unreachable"
+      echo "Health: $health"
+      exit 0
+      ;;
+    deactivated|build_failed|update_failed|canceled)
+      echo "DEPLOY FAILED: $deploy_status"
+      exit 1
+      ;;
+  esac
+
+  sleep 30
+done


### PR DESCRIPTION
## Summary
- `scripts/watch-ci.sh` — polls `gh pr checks` every 30s, reports pass/fail/pending, exits on completion
- `scripts/watch-deploy.sh` — takes a service ID and commit SHA, waits for a deploy matching that commit to appear, then tracks it to a terminal state with health check verification
- `.claude/skills/committing-merging-and-deploying-changes.md` — full commit-to-deploy workflow skill that uses Monitor to stream both scripts

## Test plan
- [x] `watch-ci.sh` used successfully on PR #24 (2/2 checks green)
- [x] `watch-deploy.sh` tested against Render API (deploy JSON includes `commit.id` field)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)