### PR TITLE
Improve monitor script notification output

### DIFF
--- a/scripts/watch-ci.sh
+++ b/scripts/watch-ci.sh
@@ -16,7 +16,7 @@ if [ -z "$pr" ]; then
   }
 fi
 
-echo "Watching CI for PR #${pr}..."
+echo "CI #${pr}: watching..."
 
 while true; do
   # Get check status summary
@@ -28,18 +28,17 @@ while true; do
   failed=$(echo "$output" | grep -c 'fail' || true)
   pending=$(echo "$output" | grep -c 'pending' || true)
 
-  echo "PR #${pr} checks: ${passed} passed, ${failed} failed, ${pending} pending (${total} total)"
-
   if [ "$failed" -gt 0 ]; then
-    echo "CI FAILED"
+    echo "CI #${pr}: FAILED (${passed}/${total} passed, ${failed} failed)"
     echo "$output"
     exit 1
   fi
 
   if [ "$pending" -eq 0 ] && [ "$total" -gt 0 ]; then
-    echo "CI PASSED — all ${total} checks green"
+    echo "CI #${pr}: ALL GREEN (${total}/${total} passed)"
     exit 0
   fi
 
+  echo "CI #${pr}: ${passed}/${total} passed, ${pending} pending"
   sleep 30
 done

--- a/scripts/watch-deploy.sh
+++ b/scripts/watch-deploy.sh
@@ -18,8 +18,9 @@ health_url="${3:-https://cloaca.onrender.com/v1/health}"
 
 # Allow matching on short SHAs
 sha_len=${#commit_sha}
+short_sha="${commit_sha:0:7}"
 
-echo "Waiting for deploy of ${commit_sha:0:12} on service ${service_id}..."
+echo "Deploy ${short_sha}: waiting for deploy to be created..."
 
 while true; do
   result=$(render deploys list "$service_id" --output json --confirm 2>/dev/null \
@@ -38,23 +39,22 @@ print('not_found not_found')
   deploy_status="${result#* }"
 
   if [ "$deploy_id" = "not_found" ]; then
-    echo "No deploy yet for ${commit_sha:0:12}, waiting..."
     sleep 30
     continue
   fi
 
-  echo "Deploy ${deploy_id}: ${deploy_status}"
-
   case "$deploy_status" in
     live)
-      echo "DEPLOY SUCCEEDED"
       health=$(curl -sf "$health_url" 2>/dev/null) || health="unreachable"
-      echo "Health: $health"
+      echo "Deploy ${short_sha}: LIVE — health: ${health}"
       exit 0
       ;;
     deactivated|build_failed|update_failed|canceled)
-      echo "DEPLOY FAILED: $deploy_status"
+      echo "Deploy ${short_sha}: FAILED (${deploy_status})"
       exit 1
+      ;;
+    *)
+      echo "Deploy ${short_sha}: ${deploy_status}"
       ;;
   esac
 


### PR DESCRIPTION
## Summary
- Prefix every line with `CI #N:` or `Deploy <sha>:` so the key info is visible in Claude Code Monitor notifications without expanding
- Remove redundant echo lines to reduce notification noise

## Test plan
- [x] Verified output format matches what Monitor displays in notifications
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)