### PR TITLE
Optimize Dockerfile for faster deploys

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.github
+.claude
+.ruff_cache
+.pytest_cache
+__pycache__
+*.pyc
+tests
+scripts
+docker-compose.yml
+render.yaml
+sqlc.yaml
+hotspot_observations.csv
+requirements-dev.lock
+requirements.lock
+piper_state.db
+*.db

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,15 @@
 .git
 .github
 .claude
+.env
+.env*
+.mcp.json
 .ruff_cache
 .pytest_cache
 __pycache__
 *.pyc
-tests
-scripts
+/tests
+/scripts
 docker-compose.yml
 render.yaml
 sqlc.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM python:3.12-slim-bookworm
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
-
+COPY --from=ghcr.io/astral-sh/uv:0.11.6 /uv /uvx /bin/
 
 WORKDIR /app
-COPY uv.lock .
-COPY pyproject.toml .
-COPY README.md .
-RUN uv sync --frozen
+COPY uv.lock pyproject.toml README.md ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-install-project
 
 COPY . .
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-editable
 CMD ["uv", "run", "fastapi", "run", "src/cloaca/main.py"]


### PR DESCRIPTION
## Summary
- Pin uv to 0.11.6 (was `:latest`) to prevent Docker layer cache invalidation on new uv releases
- Split `uv sync` into two stages: dependencies first (`--no-install-project`), then project install after source copy — source-only changes no longer bust the dep cache
- Add `--mount=type=cache` for uv's download cache so even full rebuilds skip re-downloading wheels
- Add `.dockerignore` to cut build context from ~49MB (tests, scripts, .git, .db files, etc.)

## Test plan
- [ ] Verify deploy succeeds on Render with the new Dockerfile
- [ ] Confirm `uv sync --frozen --no-install-project` + `--no-editable` two-step works
- [ ] Check build logs to confirm cache hits on dep layer for source-only changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)