### PR TITLE
Show live progress status when Piper answers questions

### DIFF
--- a/src/cloaca/piper/bird_query.py
+++ b/src/cloaca/piper/bird_query.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import os
 import time
+from collections.abc import Awaitable, Callable
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
 
@@ -157,11 +158,29 @@ logger = logging.getLogger(__name__)
 
 client = AsyncAnthropic()
 
+ProgressCallback = Callable[[str], Awaitable[None]]
+
+
+def _tool_status(tool_name: str) -> str:
+    """Map MCP tool names to human-friendly status messages."""
+    if tool_name == "execute_query":
+        return "Querying historical database..."
+    if "hotspot" in tool_name:
+        return "Looking up hotspots..."
+    if "notable" in tool_name:
+        return "Checking notable sightings..."
+    if "taxonomy" in tool_name:
+        return "Looking up taxonomy..."
+    if "species_list" in tool_name:
+        return "Fetching species list..."
+    return "Searching eBird..."
+
 
 async def ask_bird_query(
     query: str,
     prior_messages: list[dict] | None = None,
     prior_context: str | None = None,
+    on_progress: ProgressCallback | None = None,
 ) -> tuple[str, QueryStats, list[dict]]:
     if not EBIRD_MCP_URL:
         raise RuntimeError("EBIRD_MCP_URL is not set")
@@ -215,6 +234,7 @@ async def ask_bird_query(
             )
 
             async for message_stream in runner:
+                text_started_this_turn = False
                 async for event in message_stream:
                     if event.type == "content_block_stop":
                         if event.content_block.type == "tool_use":
@@ -224,7 +244,14 @@ async def ask_bird_query(
                                 event.content_block.name,
                                 event.content_block.input,
                             )
+                            if on_progress:
+                                await on_progress(
+                                    _tool_status(event.content_block.name)
+                                )
                     elif event.type == "text":
+                        if not text_started_this_turn and on_progress:
+                            await on_progress("Writing response...")
+                            text_started_this_turn = True
                         chunks.append(event.text)
 
                 final = await message_stream.get_final_message()

--- a/src/cloaca/piper/main.py
+++ b/src/cloaca/piper/main.py
@@ -423,10 +423,31 @@ async def on_message(message: discord.Message):
                 "cache miss for message %d, built context from reply chain", ref_msg.id
             )
 
-    async with message.channel.typing():
-        response, stats, updated_messages = await ask_bird_query(
-            query, prior_messages=prior_messages, prior_context=prior_context
-        )
+    status_msg = await message.reply("*Thinking...*")
+
+    async def update_progress(status: str):
+        try:
+            await status_msg.edit(content=f"*{status}*")
+        except discord.HTTPException:
+            pass
+
+    try:
+        async with message.channel.typing():
+            response, stats, updated_messages = await ask_bird_query(
+                query,
+                prior_messages=prior_messages,
+                prior_context=prior_context,
+                on_progress=update_progress,
+            )
+    except Exception:
+        logger.exception("ask_bird_query failed")
+        try:
+            await status_msg.edit(
+                content="Sorry, something went wrong. Please try again!"
+            )
+        except discord.HTTPException:
+            pass
+        return
 
     footer = (
         f"-# {stats.elapsed_s:.0f}s · "
@@ -435,8 +456,8 @@ async def on_message(message: discord.Message):
         f"{stats.tool_calls} tool call{'s' if stats.tool_calls != 1 else ''}"
     )
     body = response or "Sorry, I couldn't find anything on that."
-    reply = await message.reply(f"{body}\n\n{footer}")
-    cache_put(reply.id, updated_messages)
+    await status_msg.edit(content=f"{body}\n\n{footer}")
+    cache_put(status_msg.id, updated_messages)
 
 
 async def start():
@@ -445,5 +466,14 @@ async def start():
 
 if __name__ == "__main__":
     import asyncio
+
+    from dotenv import load_dotenv
+
+    load_dotenv(override=True)
+
+    # Reload module-level env vars that were read before dotenv
+    import cloaca.piper.bird_query as _bq
+
+    _bq.EBIRD_MCP_URL = os.environ.get("EBIRD_MCP_URL", "")
 
     asyncio.run(start())


### PR DESCRIPTION
## Summary
- Instead of silently showing a typing indicator, Piper now immediately replies with a status message (*Thinking...*) that live-edits as work progresses (*Searching eBird...*, *Querying historical database...*, *Writing response...*)
- Final edit replaces the status with the actual answer + stats footer
- Adds error handling so failed queries show a message instead of a stale "Thinking..."
- Loads dotenv for standalone `python -m cloaca.piper.main` execution

## Test plan
- [x] Tested progress callback flow via CLI (no Discord) — status messages fire at correct points
- [x] Tested live on Discord locally with real Postgres DB — message edits work, no duplicate lifer posts
- [ ] Verify on production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)