### PR TITLE
Sync render.yaml with actual Render config

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -45,7 +45,7 @@ projects:
       autoDeployTrigger: checksPass
     databases:
     - name: piper-state-db
-      plan: starter
+      plan: basic-256mb
       region: oregon
-      databaseName: piper_state
-      user: piper
+      databaseName: piper_state_db
+      user: piper_state_db_user


### PR DESCRIPTION
## Summary
- Update database plan from legacy `starter` to `basic-256mb` to match what Render actually provisioned
- Update `databaseName` and `user` to match actual values (`piper_state_db` / `piper_state_db_user`)

**Context:** The BirdCast forecast alert stopped posting today because migration `002` (`birdcast_post_log` table) was never applied to production. The `preDeployCommand` was in render.yaml but not configured on the actual Render service. The blueprint has now been synced via the dashboard, activating the pre-deploy command — this PR just keeps render.yaml accurate so future syncs don't cause unexpected diffs.

## Test plan
- [x] `render blueprints validate` passes
- [ ] Merge triggers deploy → `alembic upgrade head` runs → migration 002 applied
- [ ] BirdCast forecast resumes posting on next 15-min poll (7 AM–noon ET)

🤖 Generated with [Claude Code](https://claude.com/claude-code)