### PR TITLE
EBD streaming ingest POC

### DIFF
--- a/.github/workflows/ebd-ingest.yml
+++ b/.github/workflows/ebd-ingest.yml
@@ -48,14 +48,21 @@ jobs:
 
       - name: Run streaming ingest
         timeout-minutes: 340
+        env:
+          INPUT_URL: ${{ inputs.url }}
+          INPUT_MAX_BYTES: ${{ inputs.max_bytes }}
+          INPUT_CHUNK_BYTES: ${{ inputs.chunk_bytes }}
+          INPUT_BLOCK_BYTES: ${{ inputs.block_bytes }}
+          INPUT_PREFIX_SUFFIX: ${{ inputs.prefix_suffix }}
+          GH_RUN_ID: ${{ github.run_id }}
         run: |
           set -o pipefail
           uv run src/cloaca/swan_lake/scripts/ingest_ebd_streaming.py \
-            --url "${{ inputs.url }}" \
-            --max-bytes "${{ inputs.max_bytes }}" \
-            --chunk-bytes "${{ inputs.chunk_bytes }}" \
-            --block-bytes "${{ inputs.block_bytes }}" \
-            --prefix-suffix="${{ inputs.prefix_suffix }}-${{ github.run_id }}" \
+            --url "$INPUT_URL" \
+            --max-bytes "$INPUT_MAX_BYTES" \
+            --chunk-bytes "$INPUT_CHUNK_BYTES" \
+            --block-bytes "$INPUT_BLOCK_BYTES" \
+            --prefix-suffix="${INPUT_PREFIX_SUFFIX}-${GH_RUN_ID}" \
             --nyc-db /tmp/ebd_nyc_gha.db \
             2>&1 | tee /tmp/ingest.log
 
@@ -74,14 +81,21 @@ jobs:
 
       - name: Run summary
         if: always()
+        env:
+          INPUT_URL: ${{ inputs.url }}
+          INPUT_MAX_BYTES: ${{ inputs.max_bytes }}
+          INPUT_CHUNK_BYTES: ${{ inputs.chunk_bytes }}
+          INPUT_PREFIX_SUFFIX: ${{ inputs.prefix_suffix }}
+          GH_RUN_ID: ${{ github.run_id }}
         run: |
+          release=$(basename "$INPUT_URL" .tar)
           {
             echo "## EBD ingest run"
             echo ""
-            echo "- URL: \`${{ inputs.url }}\`"
-            echo "- max_bytes: \`${{ inputs.max_bytes }}\`"
-            echo "- chunk_bytes: \`${{ inputs.chunk_bytes }}\`"
-            echo "- R2 prefix: \`release=$(basename ${{ inputs.url }} .tar)${{ inputs.prefix_suffix }}-${{ github.run_id }}\`"
+            echo "- URL: \`$INPUT_URL\`"
+            echo "- max_bytes: \`$INPUT_MAX_BYTES\`"
+            echo "- chunk_bytes: \`$INPUT_CHUNK_BYTES\`"
+            echo "- R2 prefix: \`release=${release}${INPUT_PREFIX_SUFFIX}-${GH_RUN_ID}\`"
             echo ""
             echo "### Final pipeline stats"
             echo '```'

--- a/.github/workflows/ebd-ingest.yml
+++ b/.github/workflows/ebd-ingest.yml
@@ -1,0 +1,108 @@
+name: EBD streaming ingest
+
+on:
+  workflow_dispatch:
+    inputs:
+      url:
+        description: EBD .tar URL
+        required: true
+        default: https://download.ebird.org/ebd/prepackaged/ebd_relMar-2026.tar
+      max_bytes:
+        description: Stop after N decompressed bytes (0 = full run; suffixes K/M/G allowed)
+        required: true
+        default: "1G"
+      chunk_bytes:
+        description: Parquet chunk rotation size
+        required: true
+        default: "500M"
+      block_bytes:
+        description: CSV reader block size
+        required: false
+        default: "64M"
+      prefix_suffix:
+        description: Suffix for R2 release prefix (run id is also appended)
+        required: true
+        default: "-gha-test"
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 350
+
+    env:
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_BUCKET: ${{ secrets.R2_BUCKET }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Disk space before
+        run: df -h /
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v2
+        with:
+          version: latest
+
+      - name: Run streaming ingest
+        timeout-minutes: 340
+        run: |
+          set -o pipefail
+          uv run src/cloaca/swan_lake/scripts/ingest_ebd_streaming.py \
+            --url "${{ inputs.url }}" \
+            --max-bytes "${{ inputs.max_bytes }}" \
+            --chunk-bytes "${{ inputs.chunk_bytes }}" \
+            --block-bytes "${{ inputs.block_bytes }}" \
+            --prefix-suffix="${{ inputs.prefix_suffix }}-${{ github.run_id }}" \
+            --nyc-db /tmp/ebd_nyc_gha.db \
+            2>&1 | tee /tmp/ingest.log
+
+      - name: Disk space after
+        if: always()
+        run: df -h /
+
+      - name: NYC DB stats
+        if: always()
+        run: |
+          if [ -f /tmp/ebd_nyc_gha.db ]; then
+            ls -lh /tmp/ebd_nyc_gha.db
+          else
+            echo "NYC DB not produced"
+          fi
+
+      - name: Run summary
+        if: always()
+        run: |
+          {
+            echo "## EBD ingest run"
+            echo ""
+            echo "- URL: \`${{ inputs.url }}\`"
+            echo "- max_bytes: \`${{ inputs.max_bytes }}\`"
+            echo "- chunk_bytes: \`${{ inputs.chunk_bytes }}\`"
+            echo "- R2 prefix: \`release=$(basename ${{ inputs.url }} .tar)${{ inputs.prefix_suffix }}-${{ github.run_id }}\`"
+            echo ""
+            echo "### Final pipeline stats"
+            echo '```'
+            tail -n 20 /tmp/ingest.log 2>/dev/null || echo "(no log captured)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload NYC DB
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ebd-nyc-db-${{ github.run_id }}
+          path: /tmp/ebd_nyc_gha.db
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload run log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ingest-log-${{ github.run_id }}
+          path: /tmp/ingest.log
+          if-no-files-found: ignore
+          retention-days: 7

--- a/src/cloaca/swan_lake/scripts/CLAUDE.md
+++ b/src/cloaca/swan_lake/scripts/CLAUDE.md
@@ -1,0 +1,205 @@
+# EBD streaming ingest
+
+This directory holds scripts that turn the monthly eBird Basic Dataset (EBD)
+release into the two databases the cloaca app cares about. The historical
+manual flow is `parse_ebd.sh` (download `.tar` to disk, stream into a giant
+DuckDB) followed by `build_ebd_nyc.sh` (filter the 5 NYC counties out of the
+full DB into the small one Piper queries on Render).
+
+`ingest_ebd_streaming.py` is the in-progress replacement: a single-pass
+pipeline that streams the tar straight from eBird's URL and produces both the
+NYC DuckDB and a remote Parquet copy of the full dataset, without ever
+materializing the 100+ GB intermediate `ebd_full.db`. As of this commit the
+script is a working **proof of concept** — the smoke test passes
+end-to-end but it has not been wired into a schedule, the Render swap step
+isn't built, and several optimization decisions are deliberately deferred.
+
+## Architecture
+
+```
+URL (HTTPS, public)
+  │  urlopen, ~23 MB/s per-IP cap
+  ▼
+TrackingStream                ← bytes_downloaded counter
+  │
+  ▼
+tarfile (mode='r|')           ← streaming, no random access
+  │  extracts inner ebd_relMMM-YYYY.txt.gz
+  ▼
+gzip.GzipFile + DecompressTracker  ← decompressed_bytes counter
+  │
+  ▼
+pyarrow.csv.open_csv          ← TSV parser, batched RecordBatches
+  │
+  ├──► NYC filter (county_code in 5 NYC FIPS codes)
+  │       └──► DuckDB Appender → src/cloaca/swan_lake/dbs/ebd_nyc.db
+  │
+  └──► Rolling Parquet writer (zstd, level 6)
+          └──► boto3 multipart upload → r2://ebd/release=<rel>/chunk_NNNNN.parquet
+                                          (uploaded async by worker thread)
+```
+
+A `rich.live.Live` panel renders progress 4×/sec in a TTY (download MB/s,
+decompress ratio, rows/sec, NYC hit rate, in-flight chunk size, R2 upload
+totals, ETA). Outside a TTY the same numbers print every 5s as plain log
+lines. SIGINT flushes the open chunk to R2 and closes the DuckDB cleanly
+before exit.
+
+## Why this shape
+
+### Why stream incrementally, not build the full DB first
+
+The locally-built `ebd_relJan-2026.db` is **138 GB** with no compression
+tuning. Even after optimization (ENUMs, FLOAT lat/lon, dropping
+`global_unique_identifier`, ZSTD-encoded Parquet) the realistic optimized
+size is 25–60 GB — still too big to materialize on a default GitHub Actions
+runner (~30 GB free after cleanup).
+
+DuckDB's `COPY ... TO 's3://...' (FORMAT PARQUET, PARTITION_BY year)` looks
+ideal but partitions force the engine to spill the whole input to its
+`temp_directory` before flushing — defeats the small-disk goal.
+
+The fix is a single in-memory fan-out: each Arrow `RecordBatch` is filtered
+to NYC and appended to the local DuckDB, *and* written to a rolling Parquet
+chunk on disk. When a chunk hits its arrow-bytes threshold, an upload thread
+ships it to R2 and the chunk file is deleted. Total disk needed = one
+in-flight chunk (~500 MB) + ebd_nyc.db (~300 MB) + DuckDB temp (a few GB).
+
+### Why two outputs
+
+- **NYC subset on Render**: small (~300 MB), cheap, what Piper actually
+  queries today. Gets scp'd onto the cloaca service's 1 GB persistent disk
+  at `/var/data/ebd_nyc.db`.
+- **Full Parquet on R2**: so questions about birds outside the 5 boroughs
+  can still be answered. R2 is $0.015/GB-month with $0 egress and queryable
+  directly via DuckDB's `httpfs` extension — no download step from a
+  laptop or from Piper.
+
+### Why R2 over alternatives
+
+R2 won on cost (~$0.50/mo for ~30 GB of optimized Parquet) and on the
+zero-egress story (DuckDB queries from anywhere are free). Other options
+considered:
+
+- **MotherDuck**: clean fit but vendor-locked.
+- **Render disk on a separate service**: $5+/mo just for storage.
+- **GitHub Releases / LFS**: 2 GB per file limit kills it.
+- **Local-only on lacie disk**: works for now but doesn't survive without
+  the laptop.
+
+## What's been validated
+
+A 300 MB smoke test against `ebd_relMar-2026` confirmed:
+
+- Streaming download from the URL: works at ~23 MB/s single-connection
+  (well above the conservative "10 MB/s" estimate the planning was based on).
+- Tar member streaming + gzip decompression on the URL stream: works.
+- pyarrow CSV parser: works with the eBird TSV (`delimiter='\t'`,
+  `quote_char=False`, `column_types` dict, `include_columns` to drop
+  `global_unique_identifier`). The `invalid_row_handler='skip'` is wired
+  for resilience but didn't fire in the smoke test.
+- NYC filter via `pc.is_in`: works; ~0.91% hit rate on the first 770K rows.
+- DuckDB Appender via `register(arrow_table) → INSERT INTO`: works; types
+  match (FLOAT, DATE, BOOLEAN, etc.).
+- Rolling Parquet (ZSTD level 6) → R2 multipart upload via boto3: works.
+- Round-trip query: DuckDB `httpfs` reading
+  `r2://ebd/release=<rel>/*.parquet` returns the same row count as the
+  local DuckDB, with the same schema preserved.
+- Live monitoring panel + non-TTY fallback: both work.
+
+## Findings that affect the production design
+
+- **Real source size**: 232 GB compressed for the World tar
+  (`ebd_relMar-2026`). The eBird page text says "39+ GB" — that is wildly
+  stale.
+- **Real download cap**: ~23 MB/s per IP (was estimated at 10 MB/s).
+  Resulting wall time for the full tar is **~2.8 hours**, not 6.4h —
+  comfortably under the GHA 6h runner limit.
+- **Per-IP, not per-connection cap**: tested with 1 vs 4 parallel ranged
+  downloads. Aggregate throughput across 4 connections (~21 MB/s) matched
+  a single connection (~23 MB/s). **Parallel ranged downloads do not
+  help.**
+- **Source ordering**: the inner `.txt.gz` is sorted chronologically (the
+  first 300 MB was 100% 2011 observations). This means:
+  1. The NYC subset cannot be built from a partial stream — we have to
+     read the entire 232 GB to capture all 14.7M NYC rows.
+  2. Parquet chunks land in date order on R2, so date-range queries
+     ("last 5 years") naturally hit only the most recent chunks even
+     without explicit partitioning. A future reshuffle pass to
+     `year=YYYY/` partitions is straightforward but not blocking.
+- **Bottleneck is parsing, not download**: the smoke test sustained
+  ~12 MB/s downloaded while pulling at ~23 MB/s would be possible; the
+  delta is the pyarrow CSV parser holding the read pipeline back. If
+  end-to-end time becomes a problem, parallel decompression via
+  `rapidgzip` + `use_threads=True` on the parser would help. Today it
+  doesn't matter.
+
+## What's deliberately NOT built yet
+
+- **Schedule / orchestration.** No GHA workflow, no cron, no Render cron
+  job. Today the script is run by hand. The deploy plan
+  (`~/.claude/plans/i-wanted-to-explore-joyful-walrus.md`) covers options
+  (self-hosted GHA on the lacie machine vs. an ephemeral VPS spun up by
+  GHA vs. a Render cron service). No decision yet.
+- **Render scp + atomic swap + redeploy.** The script writes
+  `ebd_nyc.db` locally; nothing pushes it to `/var/data/ebd_nyc.db.new`
+  on the cloaca service or triggers a redeploy. Memory entries
+  `reference_render_scp.md` and `reference_render_deploy.md` have the
+  command shapes.
+- **URL-pattern handling.** The URL is hard-coded per run; production
+  needs to compute `ebd_relMMM-YYYY.tar` from the current date (eBird
+  releases on the 15th).
+- **ENUM-backed NYC schema.** The smoke test uses plain VARCHAR for what
+  `build_ebd_nyc.sh` casts to `category_t`, `protocol_t`,
+  `locality_type_t`, `exotic_code_t`. Worth restoring before this
+  replaces `build_ebd_nyc.sh` so downstream Piper queries don't break.
+- **Schema sort within chunks.** Each Parquet chunk is currently written
+  in input order. A cheap per-chunk sort by
+  `(state_code, observation_date)` would meaningfully improve column
+  compression — never measured.
+- **Stage 2 reshuffle.** Optional follow-up to repartition the input-order
+  chunks into `year=YYYY/` (or finer) Parquet partitions for query
+  pruning. Easy to express as a GHA matrix where each worker handles a
+  range of chunks.
+- **Resume on disconnect.** The single `urlopen` has no retry / range
+  resume. For a 2.8h job that is a real risk on flaky networks. Add
+  a `Range`-based resume around a chunk-boundary checkpoint when this
+  goes to production.
+- **Cleanup of smoke-test artifacts.** Local
+  `src/cloaca/swan_lake/dbs/ebd_nyc_smoketest.db` and the
+  `release=<rel>-smoketest/` R2 prefix are still around for inspection.
+
+## Running it
+
+```bash
+# Smoke test (~300 MB decompressed, ~15 seconds, 2 chunks to R2)
+uv run src/cloaca/swan_lake/scripts/ingest_ebd_streaming.py \
+  --url "https://download.ebird.org/ebd/prepackaged/ebd_relMar-2026.tar" \
+  --max-bytes 300M --chunk-bytes 80M --block-bytes 16M \
+  --prefix-suffix=-smoketest
+
+# Skip R2 entirely and write Parquet to a local workdir
+uv run src/cloaca/swan_lake/scripts/ingest_ebd_streaming.py \
+  --url "..." --dry-run-r2 --workdir /tmp/ebd-out --max-bytes 50M
+
+# Full run (no caps) — expect ~2.8 hours wall time end-to-end
+uv run src/cloaca/swan_lake/scripts/ingest_ebd_streaming.py \
+  --url "https://download.ebird.org/ebd/prepackaged/ebd_relMar-2026.tar"
+```
+
+`uv run` reads the PEP 723 inline metadata block at the top of the script
+and provisions `pyarrow`, `boto3`, `duckdb`, `rich`, `python-dotenv` into an
+ephemeral venv. The script reads R2 credentials from `.env` at the repo
+root (`R2_ACCOUNT_ID`, `R2_BUCKET`, `R2_ACCESS_KEY_ID`,
+`R2_SECRET_ACCESS_KEY`).
+
+Querying the R2-hosted Parquet from anywhere with DuckDB:
+
+```sql
+INSTALL httpfs; LOAD httpfs;
+CREATE OR REPLACE SECRET ebd_r2 (
+    TYPE r2,
+    KEY_ID '...', SECRET '...', ACCOUNT_ID '...'
+);
+SELECT count(*) FROM read_parquet('r2://ebd/release=ebd_relMar-2026/*.parquet');
+```

--- a/src/cloaca/swan_lake/scripts/ingest_ebd_streaming.py
+++ b/src/cloaca/swan_lake/scripts/ingest_ebd_streaming.py
@@ -1,0 +1,661 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#   "duckdb>=1.3",
+#   "pyarrow>=17",
+#   "boto3>=1.34",
+#   "rich>=13",
+#   "python-dotenv>=1.0",
+# ]
+# ///
+"""Stream-ingest the eBird EBD tar from a URL.
+
+One pass: HTTP stream -> tar -> gunzip -> TSV parse -> fan out to two sinks:
+  1. Rolling Parquet chunks uploaded to Cloudflare R2 (full dataset).
+  2. NYC-county-filtered rows appended into a local DuckDB (Render-bound subset).
+
+Run with:  uv run src/cloaca/swan_lake/scripts/ingest_ebd_streaming.py --url ...
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import os
+import queue
+import signal
+import sys
+import tarfile
+import tempfile
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+from urllib.request import Request, urlopen
+
+import boto3
+import duckdb
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.csv as pa_csv
+import pyarrow.parquet as pq
+from dotenv import load_dotenv
+from rich.console import Console
+from rich.live import Live
+from rich.panel import Panel
+from rich.table import Table
+
+
+NYC_COUNTIES = ["US-NY-061", "US-NY-047", "US-NY-081", "US-NY-005", "US-NY-085"]
+
+# (raw TSV column name, snake_case name, arrow type). Order = output schema order.
+# GLOBAL UNIQUE IDENTIFIER intentionally dropped (long string per row, never queried).
+EBD_COLUMNS: list[tuple[str, str, pa.DataType]] = [
+    ("CATEGORY", "category", pa.string()),
+    ("COMMON NAME", "common_name", pa.string()),
+    ("SCIENTIFIC NAME", "scientific_name", pa.string()),
+    ("SUBSPECIES COMMON NAME", "subspecies_common_name", pa.string()),
+    ("SUBSPECIES SCIENTIFIC NAME", "subspecies_scientific_name", pa.string()),
+    ("EXOTIC CODE", "exotic_code", pa.string()),
+    ("OBSERVATION COUNT", "observation_count", pa.string()),  # may be 'X'
+    ("COUNTRY CODE", "country_code", pa.string()),
+    ("STATE CODE", "state_code", pa.string()),
+    ("COUNTY CODE", "county_code", pa.string()),
+    ("LOCALITY", "locality", pa.string()),
+    ("LOCALITY ID", "locality_id", pa.string()),
+    ("LOCALITY TYPE", "locality_type", pa.string()),
+    ("LATITUDE", "latitude", pa.float32()),
+    ("LONGITUDE", "longitude", pa.float32()),
+    ("OBSERVATION DATE", "observation_date", pa.date32()),
+    ("SAMPLING EVENT IDENTIFIER", "sampling_event_identifier", pa.string()),
+    ("PROTOCOL NAME", "protocol_name", pa.string()),
+    ("DURATION MINUTES", "duration_minutes", pa.int32()),
+    ("EFFORT DISTANCE KM", "effort_distance_km", pa.float32()),
+    ("NUMBER OBSERVERS", "number_observers", pa.int16()),
+    ("ALL SPECIES REPORTED", "all_species_reported", pa.bool_()),
+    ("GROUP IDENTIFIER", "group_identifier", pa.string()),
+    ("APPROVED", "approved", pa.bool_()),
+    ("REVIEWED", "reviewed", pa.bool_()),
+]
+
+INCLUDE_COLS = [c[0] for c in EBD_COLUMNS]
+SNAKE_NAMES = [c[1] for c in EBD_COLUMNS]
+ARROW_TYPES = {c[0]: c[2] for c in EBD_COLUMNS}
+ARROW_SCHEMA = pa.schema([(c[1], c[2]) for c in EBD_COLUMNS])
+
+
+# === Stats =====================================================================
+
+
+@dataclass
+class Stats:
+    started_at: float = field(default_factory=time.monotonic)
+    total_bytes: int = 0
+    bytes_downloaded: int = 0
+    decompressed_bytes: int = 0
+    rows_parsed: int = 0
+    nyc_rows_kept: int = 0
+    chunks_started: int = 1
+    chunks_uploaded: int = 0
+    bytes_uploaded: int = 0
+    current_chunk_rows: int = 0
+    current_chunk_bytes: int = 0
+    last_uploaded_key: str = ""
+    invalid_rows: int = 0
+    status: str = "starting"
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def snapshot(self) -> dict:
+        with self.lock:
+            d = {
+                "elapsed": time.monotonic() - self.started_at,
+                "total_bytes": self.total_bytes,
+                "bytes_downloaded": self.bytes_downloaded,
+                "decompressed_bytes": self.decompressed_bytes,
+                "rows_parsed": self.rows_parsed,
+                "nyc_rows_kept": self.nyc_rows_kept,
+                "chunks_started": self.chunks_started,
+                "chunks_uploaded": self.chunks_uploaded,
+                "bytes_uploaded": self.bytes_uploaded,
+                "current_chunk_rows": self.current_chunk_rows,
+                "current_chunk_bytes": self.current_chunk_bytes,
+                "last_uploaded_key": self.last_uploaded_key,
+                "invalid_rows": self.invalid_rows,
+                "status": self.status,
+            }
+        e = d["elapsed"] or 1e-9
+        d["dl_avg_mbps"] = d["bytes_downloaded"] / 1e6 / e
+        d["decomp_avg_mbps"] = d["decompressed_bytes"] / 1e6 / e
+        d["rows_per_s"] = d["rows_parsed"] / e
+        d["decomp_ratio"] = (
+            d["decompressed_bytes"] / d["bytes_downloaded"]
+            if d["bytes_downloaded"]
+            else 0
+        )
+        d["nyc_hit_rate"] = (
+            d["nyc_rows_kept"] / d["rows_parsed"] if d["rows_parsed"] else 0
+        )
+        d["dl_eta_sec"] = (
+            (d["total_bytes"] - d["bytes_downloaded"]) / 1e6 / d["dl_avg_mbps"]
+            if d["total_bytes"] > 0 and d["dl_avg_mbps"] > 0
+            else None
+        )
+        return d
+
+
+def fmt_bytes(n: float) -> str:
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if abs(n) < 1024:
+            return f"{n:.2f} {unit}"
+        n /= 1024
+    return f"{n:.2f} PB"
+
+
+def fmt_duration(s: Optional[float]) -> str:
+    if s is None:
+        return "—"
+    s = int(s)
+    h, r = divmod(s, 3600)
+    m, s = divmod(r, 60)
+    if h:
+        return f"{h}h{m:02d}m{s:02d}s"
+    if m:
+        return f"{m}m{s:02d}s"
+    return f"{s}s"
+
+
+# === I/O wrappers ==============================================================
+
+
+class TrackingStream:
+    def __init__(self, raw, stats: Stats):
+        self._raw = raw
+        self._stats = stats
+        self._closed = False
+
+    def read(self, n: int = -1) -> bytes:
+        data = self._raw.read(n) if n != -1 else self._raw.read()
+        if data:
+            with self._stats.lock:
+                self._stats.bytes_downloaded += len(data)
+        return data
+
+    def readable(self) -> bool:
+        return True
+
+    def writable(self) -> bool:
+        return False
+
+    def seekable(self) -> bool:
+        return False
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def close(self):
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            self._raw.close()
+        except Exception:
+            pass
+
+
+class DecompressTracker:
+    def __init__(self, gz, stats: Stats):
+        self._gz = gz
+        self._stats = stats
+        self._closed = False
+
+    def read(self, n: int = -1) -> bytes:
+        data = self._gz.read(n)
+        if data:
+            with self._stats.lock:
+                self._stats.decompressed_bytes += len(data)
+        return data
+
+    def readable(self) -> bool:
+        return True
+
+    def writable(self) -> bool:
+        return False
+
+    def seekable(self) -> bool:
+        return False
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def close(self):
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            self._gz.close()
+        except Exception:
+            pass
+
+
+# === Live monitor ==============================================================
+
+
+def render_panel(stats: Stats, args) -> Panel:
+    s = stats.snapshot()
+    t = Table.grid(padding=(0, 2))
+    t.add_column(style="cyan", no_wrap=True)
+    t.add_column()
+
+    t.add_row("Status", f"[bold]{s['status']}[/]")
+    t.add_row("Elapsed", fmt_duration(s["elapsed"]))
+    t.add_row("", "")
+
+    if s["total_bytes"] > 0:
+        pct = 100 * s["bytes_downloaded"] / s["total_bytes"]
+        eta = fmt_duration(s["dl_eta_sec"])
+        t.add_row(
+            "Downloaded",
+            f"{fmt_bytes(s['bytes_downloaded'])} / {fmt_bytes(s['total_bytes'])} "
+            f"({pct:.2f}%) · {s['dl_avg_mbps']:.1f} MB/s avg · ETA {eta}",
+        )
+    else:
+        t.add_row(
+            "Downloaded",
+            f"{fmt_bytes(s['bytes_downloaded'])} · {s['dl_avg_mbps']:.1f} MB/s avg",
+        )
+
+    t.add_row(
+        "Decompressed",
+        f"{fmt_bytes(s['decompressed_bytes'])} · {s['decomp_avg_mbps']:.1f} MB/s · "
+        f"ratio {s['decomp_ratio']:.2f}×",
+    )
+    t.add_row(
+        "Rows parsed",
+        f"{s['rows_parsed']:,} · {s['rows_per_s']:,.0f} rows/s"
+        + (f" · skipped {s['invalid_rows']:,}" if s["invalid_rows"] else ""),
+    )
+    t.add_row(
+        "NYC kept",
+        f"{s['nyc_rows_kept']:,} ({s['nyc_hit_rate'] * 100:.4f}%)",
+    )
+    t.add_row(
+        "Current chunk",
+        f"#{s['chunks_started']} · {s['current_chunk_rows']:,} rows · "
+        f"~{fmt_bytes(s['current_chunk_bytes'])} arrow",
+    )
+    t.add_row(
+        "R2 uploaded",
+        f"{s['chunks_uploaded']} chunk(s) · {fmt_bytes(s['bytes_uploaded'])}",
+    )
+    if s["last_uploaded_key"]:
+        t.add_row("Last upload", s["last_uploaded_key"])
+
+    return Panel(t, title="[bold]EBD streaming ingest[/]", border_style="blue")
+
+
+def monitor_loop(stats: Stats, args, stop_event: threading.Event, console: Console):
+    if console.is_terminal:
+        with Live(
+            render_panel(stats, args), console=console, refresh_per_second=4
+        ) as live:
+            while not stop_event.is_set():
+                live.update(render_panel(stats, args))
+                stop_event.wait(0.25)
+            live.update(render_panel(stats, args))
+        return
+    while not stop_event.is_set():
+        stop_event.wait(5)
+        s = stats.snapshot()
+        print(
+            f"[{fmt_duration(s['elapsed'])}] "
+            f"dl={fmt_bytes(s['bytes_downloaded'])}/{fmt_bytes(s['total_bytes'])} "
+            f"({s['dl_avg_mbps']:.1f} MB/s) | "
+            f"rows={s['rows_parsed']:,} ({s['rows_per_s']:,.0f}/s) | "
+            f"nyc={s['nyc_rows_kept']:,} | "
+            f"chunks {s['chunks_uploaded']}/{s['chunks_started']}",
+            flush=True,
+        )
+
+
+# === R2 sink ===================================================================
+
+
+def upload_worker(q: queue.Queue, s3, bucket: str, stats: Stats):
+    while True:
+        item = q.get()
+        if item is None:
+            q.task_done()
+            return
+        local_path, key = item
+        try:
+            sz = local_path.stat().st_size
+            s3.upload_file(str(local_path), bucket, key)
+            with stats.lock:
+                stats.chunks_uploaded += 1
+                stats.bytes_uploaded += sz
+                stats.last_uploaded_key = key
+            local_path.unlink(missing_ok=True)
+        except Exception as e:
+            print(f"upload failed for {key}: {e}", file=sys.stderr)
+        finally:
+            q.task_done()
+
+
+# === DuckDB sink ===============================================================
+
+
+CREATE_NYC_TABLE = """
+CREATE TABLE ebd_nyc (
+    category VARCHAR,
+    common_name VARCHAR,
+    scientific_name VARCHAR,
+    subspecies_common_name VARCHAR,
+    subspecies_scientific_name VARCHAR,
+    exotic_code VARCHAR,
+    observation_count VARCHAR,
+    country_code VARCHAR,
+    state_code VARCHAR,
+    county_code VARCHAR,
+    locality VARCHAR,
+    locality_id VARCHAR,
+    locality_type VARCHAR,
+    latitude FLOAT,
+    longitude FLOAT,
+    observation_date DATE,
+    sampling_event_identifier VARCHAR,
+    protocol_name VARCHAR,
+    duration_minutes INTEGER,
+    effort_distance_km FLOAT,
+    number_observers SMALLINT,
+    all_species_reported BOOLEAN,
+    group_identifier VARCHAR,
+    approved BOOLEAN,
+    reviewed BOOLEAN
+)
+"""
+
+
+# === Main =====================================================================
+
+
+def parse_size(s: str) -> int:
+    s = s.strip().upper()
+    if s.endswith("K"):
+        return int(float(s[:-1]) * 1024)
+    if s.endswith("M"):
+        return int(float(s[:-1]) * 1024 * 1024)
+    if s.endswith("G"):
+        return int(float(s[:-1]) * 1024 * 1024 * 1024)
+    return int(s)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--url", required=True, help="EBD .tar URL")
+    p.add_argument(
+        "--release", default=None, help="Release name for R2 prefix; defaults from URL"
+    )
+    p.add_argument(
+        "--prefix-suffix",
+        default="",
+        help="Suffix appended to release prefix (e.g. -smoketest)",
+    )
+    p.add_argument("--nyc-db", default="src/cloaca/swan_lake/dbs/ebd_nyc_smoketest.db")
+    p.add_argument(
+        "--max-bytes",
+        default="0",
+        help="Stop after N decompressed bytes (0=no limit). Suffixes K/M/G.",
+    )
+    p.add_argument("--max-rows", type=int, default=0)
+    p.add_argument("--max-chunks", type=int, default=0)
+    p.add_argument(
+        "--chunk-bytes",
+        default="500M",
+        help="Rotate Parquet chunk after ~N arrow bytes accumulated.",
+    )
+    p.add_argument("--block-bytes", default="64M", help="CSV reader block size.")
+    p.add_argument("--workdir", default=None)
+    p.add_argument(
+        "--dry-run-r2",
+        action="store_true",
+        help="Skip R2 upload (write Parquet to workdir only)",
+    )
+    args = p.parse_args()
+
+    args.max_bytes = parse_size(args.max_bytes)
+    args.chunk_bytes = parse_size(args.chunk_bytes)
+    args.block_bytes = parse_size(args.block_bytes)
+
+    load_dotenv()
+    account_id = os.environ["R2_ACCOUNT_ID"]
+    bucket = os.environ["R2_BUCKET"]
+    access_key_id = os.environ["R2_ACCESS_KEY_ID"]
+    secret_key = os.environ["R2_SECRET_ACCESS_KEY"]
+
+    release = args.release or Path(args.url.rsplit("/", 1)[-1]).stem
+    prefix = f"release={release}{args.prefix_suffix}"
+
+    workdir = (
+        Path(args.workdir)
+        if args.workdir
+        else Path(tempfile.mkdtemp(prefix="ebd-ingest-"))
+    )
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    nyc_db_path = Path(args.nyc_db)
+    nyc_db_path.parent.mkdir(parents=True, exist_ok=True)
+    if nyc_db_path.exists():
+        nyc_db_path.unlink()
+
+    console = Console()
+    stats = Stats()
+    stop_event = threading.Event()
+
+    def _sig(_signum, _frame):
+        with stats.lock:
+            stats.status = "stopping (signal)"
+        stop_event.set()
+
+    signal.signal(signal.SIGINT, _sig)
+    signal.signal(signal.SIGTERM, _sig)
+
+    s3 = None
+    worker = None
+    upload_q: queue.Queue = queue.Queue(maxsize=4)
+    if not args.dry_run_r2:
+        s3 = boto3.client(
+            "s3",
+            endpoint_url=f"https://{account_id}.r2.cloudflarestorage.com",
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_key,
+            region_name="auto",
+        )
+        worker = threading.Thread(
+            target=upload_worker,
+            args=(upload_q, s3, bucket, stats),
+            name="r2-uploader",
+            daemon=True,
+        )
+        worker.start()
+
+    monitor = threading.Thread(
+        target=monitor_loop,
+        args=(stats, args, stop_event, console),
+        name="monitor",
+        daemon=True,
+    )
+    monitor.start()
+
+    con = duckdb.connect(str(nyc_db_path))
+    con.execute(CREATE_NYC_TABLE)
+
+    try:
+        with urlopen(Request(args.url, method="HEAD"), timeout=30) as r:
+            cl = r.headers.get("Content-Length")
+            if cl:
+                with stats.lock:
+                    stats.total_bytes = int(cl)
+    except Exception as e:
+        print(f"HEAD failed (non-fatal): {e}", file=sys.stderr)
+
+    with stats.lock:
+        stats.status = "downloading"
+
+    chunk_writer: Optional[pq.ParquetWriter] = None
+    chunk_path: Optional[Path] = None
+    chunk_idx = 1
+    chunk_arrow_bytes = 0
+    nyc_value_set = pa.array(NYC_COUNTIES)
+
+    def open_new_chunk():
+        nonlocal chunk_writer, chunk_path, chunk_arrow_bytes
+        chunk_path = workdir / f"chunk_{chunk_idx:05d}.parquet"
+        chunk_writer = pq.ParquetWriter(
+            chunk_path, schema=ARROW_SCHEMA, compression="zstd", compression_level=6
+        )
+        chunk_arrow_bytes = 0
+        with stats.lock:
+            stats.chunks_started = chunk_idx
+            stats.current_chunk_rows = 0
+            stats.current_chunk_bytes = 0
+
+    def finalize_chunk():
+        nonlocal chunk_writer, chunk_path, chunk_idx
+        if chunk_writer is None or chunk_path is None:
+            return
+        chunk_writer.close()
+        chunk_writer = None
+        sz = chunk_path.stat().st_size
+        key = f"{prefix}/{chunk_path.name}"
+        if not args.dry_run_r2:
+            upload_q.put((chunk_path, key))
+        else:
+            with stats.lock:
+                stats.chunks_uploaded += 1
+                stats.bytes_uploaded += sz
+                stats.last_uploaded_key = f"(dry-run) {chunk_path}"
+        chunk_idx += 1
+
+    open_new_chunk()
+
+    raw = urlopen(args.url, timeout=300)
+    tracked_raw = TrackingStream(raw, stats)
+    tar = tarfile.open(fileobj=tracked_raw, mode="r|")
+
+    inner = None
+    for member in tar:
+        if member.name.endswith(".txt.gz"):
+            inner = tar.extractfile(member)
+            break
+    if inner is None:
+        raise RuntimeError("No .txt.gz member in tar")
+
+    decomp = DecompressTracker(gzip.GzipFile(fileobj=inner, mode="rb"), stats)
+
+    def _on_invalid(row):
+        with stats.lock:
+            stats.invalid_rows += 1
+        return "skip"
+
+    read_options = pa_csv.ReadOptions(block_size=args.block_bytes)
+    parse_options = pa_csv.ParseOptions(
+        delimiter="\t", quote_char=False, invalid_row_handler=_on_invalid
+    )
+    convert_options = pa_csv.ConvertOptions(
+        column_types=ARROW_TYPES,
+        include_columns=INCLUDE_COLS,
+        strings_can_be_null=True,
+        null_values=[""],
+        true_values=["1"],
+        false_values=["0"],
+    )
+
+    with stats.lock:
+        stats.status = "streaming"
+
+    try:
+        reader = pa_csv.open_csv(
+            decomp,
+            read_options=read_options,
+            parse_options=parse_options,
+            convert_options=convert_options,
+        )
+
+        for batch in reader:
+            if stop_event.is_set():
+                break
+
+            batch = batch.rename_columns(SNAKE_NAMES)
+            n_rows = batch.num_rows
+
+            with stats.lock:
+                stats.rows_parsed += n_rows
+
+            mask = pc.is_in(batch.column("county_code"), value_set=nyc_value_set)
+            nyc = batch.filter(mask)
+            if nyc.num_rows > 0:
+                con.register("nyc_arrow_view", pa.Table.from_batches([nyc]))
+                con.execute("INSERT INTO ebd_nyc SELECT * FROM nyc_arrow_view")
+                con.unregister("nyc_arrow_view")
+                with stats.lock:
+                    stats.nyc_rows_kept += nyc.num_rows
+
+            chunk_writer.write_batch(batch)
+            chunk_arrow_bytes += batch.nbytes
+
+            with stats.lock:
+                stats.current_chunk_rows += n_rows
+                stats.current_chunk_bytes = chunk_arrow_bytes
+
+            if chunk_arrow_bytes >= args.chunk_bytes:
+                finalize_chunk()
+                open_new_chunk()
+
+            with stats.lock:
+                done = (
+                    (args.max_bytes and stats.decompressed_bytes >= args.max_bytes)
+                    or (args.max_rows and stats.rows_parsed >= args.max_rows)
+                    or (args.max_chunks and stats.chunks_uploaded >= args.max_chunks)
+                )
+            if done:
+                stop_event.set()
+    finally:
+        with stats.lock:
+            stats.status = "finalizing"
+        finalize_chunk()
+        try:
+            tar.close()
+        except Exception:
+            pass
+        tracked_raw.close()
+
+        if worker is not None:
+            upload_q.put(None)
+            upload_q.join()
+
+        con.close()
+
+        with stats.lock:
+            stats.status = "done"
+        stop_event.set()
+        monitor.join(timeout=2)
+
+    s = stats.snapshot()
+    console.print(
+        f"\n[bold green]Done[/]: {s['rows_parsed']:,} rows "
+        f"({s['nyc_rows_kept']:,} NYC) · "
+        f"{s['chunks_uploaded']} chunks ({fmt_bytes(s['bytes_uploaded'])}) · "
+        f"{fmt_duration(s['elapsed'])}"
+    )
+    console.print(f"NYC DB: [cyan]{nyc_db_path}[/]")
+    console.print(f"R2 prefix: [cyan]r2://{bucket}/{prefix}/[/]")
+    if args.dry_run_r2:
+        console.print(f"(dry-run) Parquet files retained in [cyan]{workdir}[/]")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cloaca/swan_lake/scripts/ingest_ebd_streaming.py
+++ b/src/cloaca/swan_lake/scripts/ingest_ebd_streaming.py
@@ -455,8 +455,11 @@ def main() -> int:
     stop_event = threading.Event()
 
     def _sig(_signum, _frame):
-        with stats.lock:
-            stats.status = "stopping (signal)"
+        # Signal handlers run on the main thread between bytecodes; if the
+        # main thread is inside `with stats.lock:` when this fires, taking the
+        # non-reentrant lock here would deadlock. Status writes don't need
+        # consistency with anything else for telemetry, so just assign.
+        stats.status = "stopping (signal)"
         stop_event.set()
 
     signal.signal(signal.SIGINT, _sig)


### PR DESCRIPTION
## Summary

Single-pass Python pipeline that streams the monthly eBird Basic Dataset tar straight from its URL and fans the data into:
- a **NYC-filtered DuckDB** (the 5 boroughs, ~14M rows; replaces what `build_ebd_nyc.sh` produces)
- a **rolling ZSTD-compressed Parquet on Cloudflare R2** (the full dataset, queryable via DuckDB `httpfs`)

…in a single read of the source, with ~2–5 GB of working disk regardless of the 232 GB source size. Avoids ever materializing the multi-hundred-GB intermediate `ebd_full.db`.

## What's in this PR

- `src/cloaca/swan_lake/scripts/ingest_ebd_streaming.py` — the pipeline. PEP 723 inline-deps script, run via `uv run`.
- `src/cloaca/swan_lake/scripts/CLAUDE.md` — architecture notes, what's validated, what's deliberately deferred, and the findings that affect production planning.

## Status

This is a **proof of concept**. The smoke test passes end-to-end (see below) but production wrap-up is not in this PR:
- No GHA workflow / cron / schedule
- No Render scp + atomic swap + redeploy step
- No URL-pattern resolver (you pass `--url ...` by hand)
- NYC schema uses plain VARCHAR rather than `build_ebd_nyc.sh`'s ENUM-backed types — needs to be restored before this replaces the existing flow
- No retry / range-resume on download disconnect

## Smoke test (passed)

300 MB decompressed pulled from `ebd_relMar-2026.tar`, ~15 seconds wallclock:

| Stage | Result |
|---|---|
| URL → tar → gunzip → CSV stream | ✅ 770K rows parsed |
| NYC county filter → DuckDB Appender | ✅ 7,004 rows, all 5 boroughs, 271 species |
| Rolling Parquet → R2 multipart upload | ✅ 2 chunks, ~31 MB compressed total |
| Round-trip query (`r2://ebd/release=…/*.parquet` via DuckDB `httpfs`) | ✅ row counts match local DB |
| Live progress monitor (rich Live + non-TTY fallback) | ✅ |
| `--max-bytes` / `--max-rows` / `--max-chunks` early stop | ✅ |

## Findings worth flagging (full list in CLAUDE.md)

- **Real source size is 232 GB**, not "39+ GB" as the eBird page text says.
- **Real per-IP download cap is ~23 MB/s**, not 10 MB/s. Production wall time becomes ~2.8 h (well under GHA's 6h limit) instead of 6.4 h.
- **Cap is per-IP, not per-connection** — verified with parallel ranged-download test. Parallel downloads do not help.
- **Source TSV is sorted chronologically** — first 300 MB was 100% 2011 observations. Means we can't terminate early when building the NYC subset, but Parquet chunks naturally have date locality for query-time skipping without explicit partitioning.
- **Parsing is the bottleneck, not download** — the smoke test sustained ~12 MB/s through the parser despite the link being capable of ~23 MB/s. `rapidgzip` for parallel decompression is the lever if this becomes a problem.

## R2 setup (already done out of band)

- Bucket `ebd` created via `wrangler r2 bucket create ebd`
- R2 API token (Object Read & Write on `ebd`) created in the dashboard
- `R2_ACCOUNT_ID`, `R2_BUCKET`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` added to `.env`

## Test plan

- [ ] Read the CLAUDE.md and confirm the deferred items match what you want
- [ ] Run the smoke test in your terminal so you can see the rich Live panel in TTY mode: `uv run src/cloaca/swan_lake/scripts/ingest_ebd_streaming.py --url "https://download.ebird.org/ebd/prepackaged/ebd_relMar-2026.tar" --max-bytes 300M --chunk-bytes 80M --prefix-suffix=-tty-test`
- [ ] (Optional) Decide on the next chunk of work: GHA wrap-up, Render swap step, or restoring ENUM-backed NYC schema
- [ ] Clean up smoke-test artifacts when done: local `src/cloaca/swan_lake/dbs/ebd_nyc_smoketest.db` and the `release=ebd_relMar-2026-smoketest/` R2 prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)