### PR TITLE
Add EBD bandwidth probe workflow

### DIFF
--- a/.github/workflows/ebd-bandwidth-probe.yml
+++ b/.github/workflows/ebd-bandwidth-probe.yml
@@ -1,0 +1,65 @@
+name: EBD bandwidth probe
+
+# Manually dispatched. 3 GHA runners pull non-overlapping byte ranges of the
+# eBird tar in parallel. If per-shard throughput stays close to the single-
+# runner baseline (~8.5 MB/s observed from a standard ubuntu-latest runner),
+# eBird's rate cap is per-connection and parallel downloaders give linear
+# scaling. If per-shard throughput drops by ~1/N, the cap is on the Azure
+# egress range and splitting buys nothing.
+
+on:
+  workflow_dispatch:
+    inputs:
+      url:
+        description: EBD .tar URL
+        required: true
+        default: https://download.ebird.org/ebd/prepackaged/ebd_relMar-2026.tar
+      bytes_per_shard:
+        description: Bytes to fetch per shard (decimal; default 1 GiB)
+        required: true
+        default: "1073741824"
+      shard_offset_gb:
+        description: Gap (GB) between shard start offsets, to ensure distinct content windows
+        required: true
+        default: "75"
+
+jobs:
+  probe:
+    name: shard ${{ matrix.shard }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2]
+
+    steps:
+      - name: Runner IP
+        run: |
+          IP=$(curl -s --max-time 10 ipinfo.io/ip || echo "unknown")
+          echo "Shard ${{ matrix.shard }} runner egress IP: $IP"
+          echo "- shard ${{ matrix.shard }} IP: \`$IP\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Range download timing
+        env:
+          URL: ${{ inputs.url }}
+          BYTES: ${{ inputs.bytes_per_shard }}
+          SHARD_OFFSET_GB: ${{ inputs.shard_offset_gb }}
+          SHARD: ${{ matrix.shard }}
+        run: |
+          OFFSET=$(( SHARD * SHARD_OFFSET_GB * 1000000000 ))
+          END=$(( OFFSET + BYTES - 1 ))
+          echo "Shard $SHARD downloading bytes $OFFSET-$END from $URL"
+          curl -s --range "$OFFSET-$END" "$URL" -o /dev/null \
+            -w "shard=$SHARD bytes=%{size_download} time_s=%{time_total} speed_Bps=%{speed_download}\n" \
+            | tee /tmp/shard.txt
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Shard $SHARD result**" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat /tmp/shard.txt >> "$GITHUB_STEP_SUMMARY"
+          # Also report Mbps for human reading
+          BPS=$(awk -F= '{for(i=1;i<=NF;i++) if($i~"speed_Bps") print $(i+1)}' /tmp/shard.txt | awk '{print $1}')
+          MBPS=$(awk -v b="$BPS" 'BEGIN{printf "%.2f", b/1000000}')
+          echo "(${MBPS} MB/s)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Tiny manual workflow that dispatches 3 GHA runners in parallel via a matrix, each fetching a non-overlapping ~1 GiB byte range of the eBird tar. Reports per-shard throughput and runner egress IP.

## Why

The 20G real-ingest run on GHA settled at ~8.5 MB/s download, much slower than the 23 MB/s a residential laptop sees. At 8.5 MB/s a full 232 GB run takes ~7h 35m, over GHA's 6h hard cap. Before designing a multi-stage download-to-R2 pipeline, we want to know: does eBird rate-limit per-connection (parallel runners scale linearly) or per-Azure-egress (parallel buys nothing)?

This workflow answers that empirically.

## Test plan

- [ ] Merge
- [ ] Dispatch with defaults (1 GiB per shard, 75 GB offsets)
- [ ] Compare per-shard MB/s against the 8.5 MB/s single-runner baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)