### PR TITLE
Run EBD ingest on self-hosted Mac runner

### DIFF
--- a/.github/workflows/ebd-ingest.yml
+++ b/.github/workflows/ebd-ingest.yml
@@ -26,8 +26,12 @@ on:
 
 jobs:
   ingest:
-    runs-on: ubuntu-latest
-    timeout-minutes: 350
+    # Self-hosted Mac runner labelled 'ebd'. No GHA 6h cap, faster CPU, and
+    # ~3× faster network to eBird than ubuntu-latest. Matched only by runners
+    # carrying both 'self-hosted' and 'ebd' labels so the existing Tests
+    # workflow stays on GHA-hosted runners.
+    runs-on: [self-hosted, ebd]
+    timeout-minutes: 720
 
     env:
       R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

Switches `ebd-ingest.yml` from `ubuntu-latest` to `[self-hosted, ebd]`. The Mac runner has no 6h cap, faster CPU, and ~3× faster network to eBird's CDN than Azure-hosted runners.

## Why

20G GHA test plateaued at 8.5 MB/s download → projected full-run wallclock 7h 35m, over GHA's 6h hard cap. Local curl from the Mac sees 23 MB/s; Apple Silicon parses faster too. Putting the runner on the Mac dissolves the time-cap problem.

## Security

The `ebd` custom label is only carried by the registered Mac runner (name `macbook-ebd`). The existing Tests workflow keeps `runs-on: ubuntu-latest` and won't pick up the self-hosted runner. The ingest workflow is `workflow_dispatch`-only, so PRs from forks cannot trigger it.

## Test plan

- [ ] Merge
- [ ] Dispatch a 1G smoke run, verify it executes on the Mac runner
- [ ] Compare wallclock and throughput vs the ubuntu-latest baseline (50s / 8.5 MB/s)
- [ ] Once validated, dispatch a full run

🤖 Generated with [Claude Code](https://claude.com/claude-code)