### PR TITLE
Add --cache-dir mode for resumable EBD ingest

### DIFF
--- a/src/cloaca/swan_lake/scripts/CLAUDE.md
+++ b/src/cloaca/swan_lake/scripts/CLAUDE.md
@@ -161,10 +161,6 @@ A 300 MB smoke test against `ebd_relMar-2026` confirmed:
   chunks into `year=YYYY/` (or finer) Parquet partitions for query
   pruning. Easy to express as a GHA matrix where each worker handles a
   range of chunks.
-- **Resume on disconnect.** The single `urlopen` has no retry / range
-  resume. For a 2.8h job that is a real risk on flaky networks. Add
-  a `Range`-based resume around a chunk-boundary checkpoint when this
-  goes to production.
 - **Cleanup of smoke-test artifacts.** Local
   `src/cloaca/swan_lake/dbs/ebd_nyc_smoketest.db` and the
   `release=<rel>-smoketest/` R2 prefix are still around for inspection.
@@ -188,10 +184,63 @@ uv run src/cloaca/swan_lake/scripts/ingest_ebd_streaming.py \
 uv run src/cloaca/swan_lake/scripts/ingest_ebd_streaming.py \
   --url "$EBD_TAR_URL" --dry-run-r2 --workdir /tmp/ebd-out --max-bytes 50M
 
-# Full run (no caps) — expect ~2.8 hours wall time end-to-end
+# Full run (no caps) — streaming mode, ~2.8h, no resume on network drop
 uv run src/cloaca/swan_lake/scripts/ingest_ebd_streaming.py \
   --url "$EBD_TAR_URL"
+
+# Full run with disk + R2 raw mirror (resumable)
+uv run src/cloaca/swan_lake/scripts/ingest_ebd_streaming.py \
+  --url "$EBD_TAR_URL" \
+  --cache-dir /Volumes/lacie_disk/ebd-cache
+# or set EBD_CACHE_DIR=/Volumes/lacie_disk/ebd-cache in .env and drop --cache-dir
 ```
+
+## --cache-dir mode (resumable)
+
+Adds a Stage 1 that materializes the raw release somewhere durable before
+processing. Stage 1 does two things:
+
+1. **Disk download with HTTP Range resume.** Writes
+   `<cache-dir>/<basename>.tar.partial` chunk by chunk. On disconnect /
+   re-run, sends a `Range: bytes=<local_size>-` and appends. Atomic-renames
+   to `<basename>.tar` once the on-disk size matches the URL's
+   `Content-Length`.
+
+2. **R2 raw mirror via boto3 multipart.** After the disk file is complete,
+   uploads to `r2://<bucket>/raw/<basename>.tar`. boto3 handles multipart
+   internally with 4-way concurrency and 64 MiB parts. If
+   `s3.head_object(...)` already returns the object at the expected
+   ContentLength, the upload is skipped.
+
+Stage 2 then opens the local `.tar` and runs the existing fan-out pipeline
+(NYC DuckDB + rolling Parquet chunks to `r2://<bucket>/release=…/`).
+
+Re-running with the same `--cache-dir` is fully idempotent:
+
+| State on retry | Stage 1 behavior |
+|---|---|
+| `.tar` exists, full size | skip disk download |
+| `.tar.partial` exists, partial size | resume HTTP from that offset |
+| `.tar.partial` somehow > total | truncate, restart |
+| R2 raw object exists, full size | skip R2 upload |
+| R2 raw object missing or wrong size | re-upload from disk |
+| Stage 2 crashed mid-run | re-run reuses the disk file; chunks overwrite by name |
+
+### What's not (yet) resumable
+
+- **Stage 2 crashes during decompression / parsing don't checkpoint
+  parser state.** A re-run starts the .tar from byte 0 again. Cheap
+  relative to network download (disk reads are 100s of MB/s, not 23 MB/s),
+  but not free.
+- **Mid-multipart R2 upload crashes restart the whole boto3
+  upload_file.** boto3 doesn't currently persist multipart state across
+  process exits; aborted multiparts may linger on R2 with no default
+  lifecycle. Configure an R2 lifecycle rule to abort incomplete
+  multiparts after N days if you re-run a lot.
+- **Disk-download response stream stalls without closing.** The 300s
+  timeout on `urlopen(..., timeout=300)` covers connect; for stalled
+  bodies you may need to Ctrl+C and let the resume logic restart from
+  the on-disk size.
 
 `uv run` reads the PEP 723 inline metadata block at the top of the script
 and provisions `pyarrow`, `boto3`, `duckdb`, `rich`, `python-dotenv` into an

--- a/src/cloaca/swan_lake/scripts/ingest_ebd_streaming.py
+++ b/src/cloaca/swan_lake/scripts/ingest_ebd_streaming.py
@@ -10,9 +10,18 @@
 # ///
 """Stream-ingest the eBird EBD tar from a URL.
 
-One pass: HTTP stream -> tar -> gunzip -> TSV parse -> fan out to two sinks:
-  1. Rolling Parquet chunks uploaded to Cloudflare R2 (full dataset).
-  2. NYC-county-filtered rows appended into a local DuckDB (Render-bound subset).
+Two run shapes:
+
+* **Streaming (default)** — HTTP -> tar -> gunzip -> TSV parse -> fan out to
+  (a) rolling Parquet chunks uploaded to R2, (b) a NYC-county-filtered local
+  DuckDB. Single pass, no on-disk staging. Network drop = restart from byte 0.
+
+* **Cached (--cache-dir <path> or env EBD_CACHE_DIR)** — adds a Stage 1 that
+  pulls the raw .tar to <cache-dir>/<basename>.tar (resumable via HTTP Range)
+  and mirrors it to r2://<bucket>/raw/<basename>.tar. Stage 2 then opens the
+  local .tar and runs the same fan-out pipeline. Re-running is idempotent: a
+  complete .tar on disk skips Stage 1 download; a complete R2 raw object
+  skips Stage 1 upload. Survives network drops at byte granularity.
 
 Run with:  uv run src/cloaca/swan_lake/scripts/ingest_ebd_streaming.py --url ...
 """
@@ -35,6 +44,7 @@ from typing import Optional
 from urllib.request import Request, urlopen
 
 import boto3
+import boto3.s3.transfer as s3_transfer
 import duckdb
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -104,6 +114,8 @@ class Stats:
     last_uploaded_key: str = ""
     invalid_rows: int = 0
     status: str = "starting"
+    # Stage 1 (--cache-dir mode) — raw .tar mirror to R2 progress.
+    stage1_r2_uploaded: int = 0
     lock: threading.Lock = field(default_factory=threading.Lock)
 
     def snapshot(self) -> dict:
@@ -123,6 +135,7 @@ class Stats:
                 "last_uploaded_key": self.last_uploaded_key,
                 "invalid_rows": self.invalid_rows,
                 "status": self.status,
+                "stage1_r2_uploaded": self.stage1_r2_uploaded,
             }
         e = d["elapsed"] or 1e-9
         d["dl_avg_mbps"] = d["bytes_downloaded"] / 1e6 / e
@@ -292,6 +305,16 @@ def render_panel(stats: Stats, args) -> Panel:
     )
     if s["last_uploaded_key"]:
         t.add_row("Last upload", s["last_uploaded_key"])
+    if s.get("stage1_r2_uploaded"):
+        if s["total_bytes"] > 0:
+            pct = 100 * s["stage1_r2_uploaded"] / s["total_bytes"]
+            t.add_row(
+                "R2 raw mirror",
+                f"{fmt_bytes(s['stage1_r2_uploaded'])} / "
+                f"{fmt_bytes(s['total_bytes'])} ({pct:.2f}%)",
+            )
+        else:
+            t.add_row("R2 raw mirror", fmt_bytes(s["stage1_r2_uploaded"]))
 
     return Panel(t, title="[bold]EBD streaming ingest[/]", border_style="blue")
 
@@ -378,6 +401,114 @@ CREATE TABLE ebd_nyc (
 """
 
 
+# === Stage 1: cache-dir resumable download =====================================
+
+
+def stage1_download_to_cache(
+    url: str,
+    cache_path: Path,
+    s3,
+    bucket: str,
+    raw_key: str,
+    stats: Stats,
+    stop_event: threading.Event,
+) -> Path:
+    """Download `url` to `cache_path` (HTTP Range-resumable) and mirror it to
+    `r2://<bucket>/<raw_key>`. Returns `cache_path` once both are complete.
+
+    Idempotent: a `.tar` file already at full size is reused; an existing R2
+    object with matching ContentLength is left alone. A partial `.tar.partial`
+    is resumed via HTTP Range.
+    """
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    partial_path = cache_path.with_suffix(cache_path.suffix + ".partial")
+
+    # Determine total size up front; populate stats.total_bytes for the panel.
+    with urlopen(Request(url, method="HEAD"), timeout=30) as r:
+        total = int(r.headers["Content-Length"])
+    with stats.lock:
+        stats.total_bytes = total
+
+    # === A. Disk download with Range resume ===
+    if cache_path.exists() and cache_path.stat().st_size == total:
+        with stats.lock:
+            stats.bytes_downloaded = total
+            stats.status = "stage1: disk cached"
+    else:
+        local_size = partial_path.stat().st_size if partial_path.exists() else 0
+        if local_size > total:
+            partial_path.unlink()
+            local_size = 0
+        with stats.lock:
+            stats.bytes_downloaded = local_size
+            stats.status = "stage1: downloading"
+
+        if local_size < total:
+            headers = {}
+            if local_size > 0:
+                headers["Range"] = f"bytes={local_size}-"
+            req = Request(url, headers=headers)
+            with urlopen(req, timeout=300) as resp:
+                with open(partial_path, "ab") as f:
+                    while not stop_event.is_set():
+                        chunk = resp.read(1 << 20)  # 1 MiB
+                        if not chunk:
+                            break
+                        f.write(chunk)
+                        with stats.lock:
+                            stats.bytes_downloaded += len(chunk)
+
+        if stop_event.is_set():
+            return partial_path  # caller can detect this via stop_event
+
+        actual = partial_path.stat().st_size
+        if actual != total:
+            raise RuntimeError(
+                f"Disk size {actual} != expected {total} for {partial_path}"
+            )
+        partial_path.rename(cache_path)
+        with stats.lock:
+            stats.status = "stage1: disk complete"
+
+    # === B. R2 raw mirror via boto3 multipart (skip if already there) ===
+    with stats.lock:
+        stats.status = "stage1: r2 mirror"
+        stats.stage1_r2_uploaded = 0
+
+    try:
+        head = s3.head_object(Bucket=bucket, Key=raw_key)
+        if head["ContentLength"] == total:
+            with stats.lock:
+                stats.stage1_r2_uploaded = total
+                stats.status = "stage1: r2 cached"
+            return cache_path
+    except Exception:
+        pass
+
+    config = s3_transfer.TransferConfig(
+        multipart_threshold=64 * 1024 * 1024,
+        multipart_chunksize=64 * 1024 * 1024,
+        max_concurrency=4,
+        use_threads=True,
+    )
+
+    def _progress(n: int):
+        with stats.lock:
+            stats.stage1_r2_uploaded += n
+
+    s3.upload_file(
+        str(cache_path),
+        bucket,
+        raw_key,
+        Config=config,
+        Callback=_progress,
+    )
+
+    with stats.lock:
+        stats.status = "stage1: r2 mirror complete"
+    return cache_path
+
+
 # === Main =====================================================================
 
 
@@ -418,6 +549,16 @@ def main() -> int:
     )
     p.add_argument("--block-bytes", default="64M", help="CSV reader block size.")
     p.add_argument("--workdir", default=None)
+    p.add_argument(
+        "--cache-dir",
+        default=os.environ.get("EBD_CACHE_DIR", ""),
+        help=(
+            "If set, run a Stage 1 that downloads the raw .tar to "
+            "<cache-dir>/<basename>.tar (HTTP Range-resumable on retry) and "
+            "mirrors it to r2://<bucket>/raw/<basename>.tar, then runs Stage 2 "
+            "from disk. Falls back to env EBD_CACHE_DIR. Empty = streaming mode."
+        ),
+    )
     p.add_argument(
         "--dry-run-r2",
         action="store_true",
@@ -495,17 +636,45 @@ def main() -> int:
     con = duckdb.connect(str(nyc_db_path))
     con.execute(CREATE_NYC_TABLE)
 
-    try:
-        with urlopen(Request(args.url, method="HEAD"), timeout=30) as r:
-            cl = r.headers.get("Content-Length")
-            if cl:
-                with stats.lock:
-                    stats.total_bytes = int(cl)
-    except Exception as e:
-        print(f"HEAD failed (non-fatal): {e}", file=sys.stderr)
+    cached_tar_path: Optional[Path] = None
+    if args.cache_dir:
+        if args.dry_run_r2:
+            raise SystemExit(
+                "--cache-dir requires R2 (it mirrors the raw .tar there). "
+                "Drop --dry-run-r2 or unset --cache-dir."
+            )
+        cache_dir = Path(args.cache_dir).expanduser()
+        basename = Path(args.url.rsplit("/", 1)[-1]).name
+        cached_tar_path = cache_dir / basename
+        raw_key = f"raw/{basename}"
+        cached_tar_path = stage1_download_to_cache(
+            args.url,
+            cached_tar_path,
+            s3,
+            bucket,
+            raw_key,
+            stats,
+            stop_event,
+        )
+        if stop_event.is_set():
+            console.print("[yellow]Stage 1 interrupted; rerun to resume.[/]")
+            return 1
+    else:
+        try:
+            with urlopen(Request(args.url, method="HEAD"), timeout=30) as r:
+                cl = r.headers.get("Content-Length")
+                if cl:
+                    with stats.lock:
+                        stats.total_bytes = int(cl)
+        except Exception as e:
+            print(f"HEAD failed (non-fatal): {e}", file=sys.stderr)
 
     with stats.lock:
-        stats.status = "downloading"
+        # bytes_downloaded carries Stage-1 disk-download progress while in
+        # cache mode; reset it for Stage 2 so the panel's "Downloaded" line
+        # tracks how far through the local .tar we've read.
+        stats.bytes_downloaded = 0
+        stats.status = "stage2: streaming" if cached_tar_path else "downloading"
 
     chunk_writer: Optional[pq.ParquetWriter] = None
     chunk_path: Optional[Path] = None
@@ -544,7 +713,10 @@ def main() -> int:
 
     open_new_chunk()
 
-    raw = urlopen(args.url, timeout=300)
+    if cached_tar_path is not None:
+        raw = open(cached_tar_path, "rb")
+    else:
+        raw = urlopen(args.url, timeout=300)
     tracked_raw = TrackingStream(raw, stats)
     tar = tarfile.open(fileobj=tracked_raw, mode="r|")
 


### PR DESCRIPTION
## Summary

Adds a Stage 1 to `ingest_ebd_streaming.py` that pulls the raw .tar to disk + mirrors it to R2 before Stage 2's existing pipeline runs. Survives network drops at byte granularity and lets you re-run the script without re-downloading or re-uploading anything that's already complete.

## What changed

- New `--cache-dir <path>` flag (also reads `EBD_CACHE_DIR` from `.env`).
- New `stage1_download_to_cache()` function:
  - HTTP Range-resumable download to `<cache-dir>/<basename>.tar.partial` → atomic-renamed to `.tar` on completion.
  - Single boto3 `upload_file` to `r2://<bucket>/raw/<basename>.tar` with 4-way multipart, skipped if `head_object` already returns the right size.
- `main()` now branches: with `--cache-dir`, runs Stage 1 then opens the cached file as Stage 2's input. Without it, the existing single-pass HTTP-streaming behavior is unchanged.
- Live monitor panel gets a new "R2 raw mirror" row that shows during Stage 1's upload phase.

## Idempotency on retry

| State | Stage 1 behavior |
|---|---|
| `.tar` exists at full size | skip download |
| `.tar.partial` exists, partial size | resume HTTP from that offset |
| `.tar.partial` somehow > total | truncate, restart |
| R2 raw object exists, full size | skip upload |
| R2 raw object missing or wrong size | re-upload |

## Verified

- Smoke test in streaming mode (no `--cache-dir`) still produces the same row counts and Parquet chunks as before. (300 MB / 15s / 770K rows / 7K NYC kept / 2 chunks to R2 — matches the baseline run from PR #38.)
- `--help` shows the new flag with env-var fallback.

Cache-dir mode itself wasn't fully smoke-tested (the only realistic test downloads the 232 GB .tar) — first real run is the test.

## Test plan

- [ ] Merge
- [ ] Set `EBD_CACHE_DIR=/Volumes/lacie_disk/ebd-cache` in .env
- [ ] Run \`uv run src/cloaca/swan_lake/scripts/ingest_ebd_streaming.py --url "https://download.ebird.org/ebd/prepackaged/ebd_relMar-2026.tar"\`
- [ ] Pull the network at some point to test resume; rerun the same command, watch it pick up
- [ ] On full success: verify the .tar is on the lacie disk, `r2://ebd/raw/ebd_relMar-2026.tar` exists, NYC DB has ~14M rows, Parquet chunks landed under `release=ebd_relMar-2026/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)