### PR TITLE
Parallel multipart raw-tar mirror to R2

### DIFF
--- a/.github/workflows/ebd-raw-mirror.yml
+++ b/.github/workflows/ebd-raw-mirror.yml
@@ -1,0 +1,144 @@
+name: Mirror eBird raw .tar to R2 (parallel multipart)
+
+# Manually dispatched. Three job stages:
+#   1. init   — single runner; HEAD URL, decide shard / part assignments,
+#               create R2 multipart upload, write manifest.
+#   2. shard  — N parallel runners (default 3); each downloads its byte range
+#               from eBird via HTTP Range and uploads it as parts to R2.
+#   3. complete — single runner; gathers part ETags, calls
+#                 complete_multipart_upload to assemble the final object.
+#
+# The bandwidth probe established that GHA runners get distinct Azure egress
+# IPs and that eBird's per-IP cap means parallel downloaders scale linearly
+# (~3× single-runner throughput at N=3). This workflow uses that property to
+# bring full-tar mirror time from ~7.5h to ~2.5h on a default ubuntu-latest
+# runner pool.
+
+on:
+  workflow_dispatch:
+    inputs:
+      url_override:
+        description: "Override the URL (default: secrets.EBD_TAR_URL)"
+        required: false
+        default: ""
+      shards:
+        description: "Number of parallel download shards"
+        required: false
+        default: "3"
+      part_size:
+        description: "Multipart part size in bytes (default 5 GB; max 5 GB per S3 spec)"
+        required: false
+        default: "5000000000"
+
+jobs:
+  init:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      already_complete: ${{ steps.init.outputs.already_complete }}
+      upload_id: ${{ steps.init.outputs.upload_id }}
+      total_bytes: ${{ steps.init.outputs.total_bytes }}
+      raw_key: ${{ steps.init.outputs.raw_key }}
+      release: ${{ steps.init.outputs.release }}
+      manifest_key: ${{ steps.init.outputs.manifest_key }}
+      shards_json: ${{ steps.init.outputs.shards_json }}
+    env:
+      EBD_TAR_URL: ${{ inputs.url_override || secrets.EBD_TAR_URL }}
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_BUCKET: ${{ secrets.R2_BUCKET }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v2
+        with:
+          version: latest
+      - name: Init multipart upload
+        id: init
+        env:
+          INPUT_SHARDS: ${{ inputs.shards }}
+          INPUT_PART_SIZE: ${{ inputs.part_size }}
+        run: |
+          uv run src/cloaca/swan_lake/scripts/ebd_multipart.py init \
+            --shards "$INPUT_SHARDS" \
+            --part-size "$INPUT_PART_SIZE"
+
+  shard:
+    needs: init
+    if: needs.init.outputs.already_complete != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.init.outputs.shards_json) }}
+
+    env:
+      EBD_TAR_URL: ${{ inputs.url_override || secrets.EBD_TAR_URL }}
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_BUCKET: ${{ secrets.R2_BUCKET }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v2
+        with:
+          version: latest
+      - name: Runner egress IP
+        run: |
+          IP=$(curl -s --max-time 10 ipinfo.io/ip || echo unknown)
+          echo "shard ${{ matrix.shard }} egress IP: $IP"
+          echo "- shard ${{ matrix.shard }} egress IP: \`$IP\`" >> "$GITHUB_STEP_SUMMARY"
+      - name: Disk space before
+        run: df -h /
+      - name: Download shard
+        env:
+          INPUT_MANIFEST: ${{ needs.init.outputs.manifest_key }}
+          INPUT_SHARD: ${{ matrix.shard }}
+        run: |
+          uv run src/cloaca/swan_lake/scripts/ebd_multipart.py shard \
+            --manifest-key "$INPUT_MANIFEST" \
+            --shard-index "$INPUT_SHARD"
+      - name: Disk space after
+        if: always()
+        run: df -h /
+
+  complete:
+    needs: [init, shard]
+    if: needs.init.outputs.already_complete != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_BUCKET: ${{ secrets.R2_BUCKET }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v2
+        with:
+          version: latest
+      - name: Complete multipart upload
+        env:
+          INPUT_MANIFEST: ${{ needs.init.outputs.manifest_key }}
+        run: |
+          uv run src/cloaca/swan_lake/scripts/ebd_multipart.py complete \
+            --manifest-key "$INPUT_MANIFEST"
+      - name: Run summary
+        if: always()
+        env:
+          UPLOAD_ID: ${{ needs.init.outputs.upload_id }}
+          RAW_KEY: ${{ needs.init.outputs.raw_key }}
+          TOTAL_BYTES: ${{ needs.init.outputs.total_bytes }}
+          RELEASE: ${{ needs.init.outputs.release }}
+        run: |
+          {
+            echo "## Raw .tar mirror complete"
+            echo ""
+            echo "- release: \`$RELEASE\`"
+            echo "- upload_id: \`$UPLOAD_ID\`"
+            echo "- raw_key: \`$RAW_KEY\`"
+            echo "- total_bytes: \`$TOTAL_BYTES\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/src/cloaca/swan_lake/scripts/ebd_multipart.py
+++ b/src/cloaca/swan_lake/scripts/ebd_multipart.py
@@ -62,7 +62,33 @@ def make_s3():
 
 def head_total_bytes(url: str) -> int:
     with urlopen(Request(url, method="HEAD"), timeout=30) as r:
-        return int(r.headers["Content-Length"])
+        cl = r.headers.get("Content-Length")
+        if cl is None:
+            raise RuntimeError("HEAD response missing Content-Length header")
+        return int(cl)
+
+
+def with_retry(fn, *, attempts: int = 4, base_delay: float = 2.0, what: str = "op"):
+    """Call fn() with exponential backoff. Re-raises the final exception if all
+    attempts fail. Used for both the Range GET against the source and the
+    upload_part call against R2; both can flake on transient network errors.
+    """
+    for attempt in range(1, attempts + 1):
+        try:
+            return fn()
+        except Exception as e:
+            if attempt == attempts:
+                raise
+            delay = base_delay * (2 ** (attempt - 1))
+            # Strip URL from error string defensively — the source URL is a
+            # secret and tracebacks from urllib include it. The message is
+            # for human eyeballing in the run log; the original exception
+            # still propagates if all attempts fail.
+            print(
+                f"  {what} attempt {attempt}/{attempts} failed: "
+                f"{type(e).__name__}; retrying in {delay:.1f}s"
+            )
+            time.sleep(delay)
 
 
 def write_gha_output(pairs: dict[str, str | int | bool]):
@@ -88,11 +114,18 @@ def compute_assignments(total_bytes: int, part_size: int, total_shards: int):
     are globally sequential 1..total_parts so the multipart upload sees them
     in order regardless of which shard wrote them.
     """
+    if total_bytes <= 0:
+        raise ValueError(f"total_bytes must be positive; got {total_bytes}")
+    s3_min_part = 5 * 1024 * 1024  # 5 MiB
     full, rem = divmod(total_bytes, part_size)
     total_parts = full + (1 if rem else 0)
     if total_parts > 10000:
         raise ValueError(
             f"{total_parts} parts exceeds S3 multipart limit of 10000 — increase part-size"
+        )
+    if total_parts > 1 and part_size < s3_min_part:
+        raise ValueError(
+            f"part_size {part_size:,} is below S3's 5 MiB minimum for non-final parts"
         )
     if total_shards > total_parts:
         raise ValueError(
@@ -144,7 +177,10 @@ def init_cmd(args):
     release = basename[: -len(".tar")]
     raw_key = f"raw/{basename}"
 
-    # Skip if final object already exists at expected size
+    # Skip if final object already exists at expected size. Only swallow the
+    # 404 "object absent" path; other errors (auth / throttling / 5xx) should
+    # surface so we don't silently start a multipart upload that's destined
+    # to fail.
     try:
         head = s3.head_object(Bucket=bucket, Key=raw_key)
         if head["ContentLength"] == total_bytes:
@@ -161,8 +197,10 @@ def init_cmd(args):
                 }
             )
             return
-    except s3.exceptions.ClientError:
-        pass
+    except s3.exceptions.ClientError as e:
+        code = e.response.get("Error", {}).get("Code", "")
+        if code not in ("404", "NoSuchKey", "NotFound"):
+            raise
 
     assignments, total_parts = compute_assignments(
         total_bytes, args.part_size, args.shards
@@ -260,7 +298,8 @@ def shard_cmd(args):
         expected_size = part_info["size"]
         state_key = _state_key(upload_id, part_num)
 
-        # Skip if already uploaded
+        # Skip if already uploaded. Narrow the swallow to NoSuchKey/404; any
+        # other ClientError (auth, throttling, 5xx) should propagate.
         try:
             existing = s3.get_object(Bucket=bucket, Key=state_key)
             data = json.loads(existing["Body"].read())
@@ -271,24 +310,31 @@ def shard_cmd(args):
                 print(f"  [{part_num:>5}] already uploaded; skipping")
                 bytes_done += expected_size
                 continue
-        except s3.exceptions.ClientError:
-            pass
+        except s3.exceptions.ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            if code not in ("404", "NoSuchKey", "NotFound"):
+                raise
 
-        # Stream-download to a temp file
+        # Stream-download to a temp file (with retry on transient network errors)
         with tempfile.NamedTemporaryFile(
             prefix=f"ebd-part-{part_num:05d}-", delete=False
         ) as tmp:
             tmp_path = tmp.name
         try:
+
+            def _download_part():
+                req = Request(url, headers={"Range": f"bytes={start}-{end}"})
+                with urlopen(req, timeout=300) as resp, open(tmp_path, "wb") as out:
+                    shutil.copyfileobj(resp, out, length=8 << 20)
+                actual = os.path.getsize(tmp_path)
+                if actual != expected_size:
+                    raise RuntimeError(
+                        f"Part {part_num}: got {actual} bytes, expected {expected_size}"
+                    )
+                return actual
+
             t0 = time.monotonic()
-            req = Request(url, headers={"Range": f"bytes={start}-{end}"})
-            with urlopen(req, timeout=300) as resp, open(tmp_path, "wb") as out:
-                shutil.copyfileobj(resp, out, length=8 << 20)
-            actual_size = os.path.getsize(tmp_path)
-            if actual_size != expected_size:
-                raise RuntimeError(
-                    f"Part {part_num}: got {actual_size} bytes, expected {expected_size}"
-                )
+            actual_size = with_retry(_download_part, what=f"part {part_num} download")
             dl_secs = time.monotonic() - t0
             dl_mbps = actual_size / 1e6 / max(dl_secs, 1e-9)
             print(
@@ -296,17 +342,20 @@ def shard_cmd(args):
                 f"in {dl_secs:.1f}s ({dl_mbps:.2f} MB/s)"
             )
 
-            # Upload as a part
+            # Upload as a part (with retry on transient R2 errors)
+            def _upload_part():
+                with open(tmp_path, "rb") as f:
+                    return s3.upload_part(
+                        Bucket=bucket,
+                        Key=raw_key,
+                        UploadId=upload_id,
+                        PartNumber=part_num,
+                        Body=f,
+                        ContentLength=actual_size,
+                    )
+
             t1 = time.monotonic()
-            with open(tmp_path, "rb") as f:
-                upload_resp = s3.upload_part(
-                    Bucket=bucket,
-                    Key=raw_key,
-                    UploadId=upload_id,
-                    PartNumber=part_num,
-                    Body=f,
-                    ContentLength=actual_size,
-                )
+            upload_resp = with_retry(_upload_part, what=f"part {part_num} upload")
             up_secs = time.monotonic() - t1
             up_mbps = actual_size / 1e6 / max(up_secs, 1e-9)
             etag = upload_resp["ETag"]

--- a/src/cloaca/swan_lake/scripts/ebd_multipart.py
+++ b/src/cloaca/swan_lake/scripts/ebd_multipart.py
@@ -1,0 +1,440 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#   "boto3>=1.34",
+#   "python-dotenv>=1.0",
+# ]
+# ///
+"""Parallel multipart download of the eBird raw .tar to Cloudflare R2.
+
+Three subcommands implement a fan-out-then-assemble pipeline using S3
+multipart upload as the assembly mechanism: the resulting R2 object is the
+byte-exact concatenation of the parts in PartNumber order, so there is no
+post-processing concatenation step.
+
+  init      HEAD the URL, decide on shard / part assignments, create the
+            multipart upload, write a manifest object to R2.
+  shard     Download one shard's contiguous byte range from the URL and
+            upload it as a span of parts. Each part's ETag is written to
+            r2://<bucket>/parts-state/<UploadId>/<NNNNN>.json so the complete
+            step can find them and retries can skip already-uploaded parts.
+  complete  List parts-state, sort by PartNumber, complete the multipart
+            upload, verify the final object's ContentLength, clean up state.
+
+Inputs come from environment variables (never command-line):
+
+  EBD_TAR_URL              source URL
+  R2_ACCOUNT_ID            R2 account id
+  R2_BUCKET                target bucket
+  R2_ACCESS_KEY_ID         R2 S3-compat key
+  R2_SECRET_ACCESS_KEY     R2 S3-compat secret
+  GITHUB_OUTPUT (init only) path the GHA outputs file (set by the runner)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import tempfile
+import time
+from urllib.request import Request, urlopen
+
+import boto3
+from dotenv import load_dotenv
+
+
+# === R2 client + URL helpers ===================================================
+
+
+def make_s3():
+    load_dotenv()
+    return boto3.client(
+        "s3",
+        endpoint_url=f"https://{os.environ['R2_ACCOUNT_ID']}.r2.cloudflarestorage.com",
+        aws_access_key_id=os.environ["R2_ACCESS_KEY_ID"],
+        aws_secret_access_key=os.environ["R2_SECRET_ACCESS_KEY"],
+        region_name="auto",
+    )
+
+
+def head_total_bytes(url: str) -> int:
+    with urlopen(Request(url, method="HEAD"), timeout=30) as r:
+        return int(r.headers["Content-Length"])
+
+
+def write_gha_output(pairs: dict[str, str | int | bool]):
+    out = os.environ.get("GITHUB_OUTPUT")
+    if not out:
+        print("(GITHUB_OUTPUT not set; skipping output file write)", file=sys.stderr)
+        return
+    with open(out, "a") as f:
+        for k, v in pairs.items():
+            if isinstance(v, bool):
+                v = "true" if v else "false"
+            f.write(f"{k}={v}\n")
+
+
+# === Assignment computation ====================================================
+
+
+def compute_assignments(total_bytes: int, part_size: int, total_shards: int):
+    """Return (assignments, total_parts).
+
+    assignments is a list of {shard_index, start_byte, end_byte, parts: [...]}
+    where each part has {part_number, start_byte, end_byte, size}. Part numbers
+    are globally sequential 1..total_parts so the multipart upload sees them
+    in order regardless of which shard wrote them.
+    """
+    full, rem = divmod(total_bytes, part_size)
+    total_parts = full + (1 if rem else 0)
+    if total_parts > 10000:
+        raise ValueError(
+            f"{total_parts} parts exceeds S3 multipart limit of 10000 — increase part-size"
+        )
+    if total_shards > total_parts:
+        raise ValueError(
+            f"{total_shards} shards but only {total_parts} parts — reduce shards"
+        )
+
+    base, extra = divmod(total_parts, total_shards)
+    assignments = []
+    next_part = 1
+    next_byte = 0
+    for shard in range(total_shards):
+        n_parts = base + (1 if shard < extra else 0)
+        shard_parts = []
+        for _ in range(n_parts):
+            sz = min(part_size, total_bytes - next_byte)
+            shard_parts.append(
+                {
+                    "part_number": next_part,
+                    "start_byte": next_byte,
+                    "end_byte": next_byte + sz - 1,
+                    "size": sz,
+                }
+            )
+            next_part += 1
+            next_byte += sz
+        assignments.append(
+            {
+                "shard_index": shard,
+                "start_byte": shard_parts[0]["start_byte"],
+                "end_byte": shard_parts[-1]["end_byte"],
+                "parts": shard_parts,
+            }
+        )
+    return assignments, total_parts
+
+
+# === init =====================================================================
+
+
+def init_cmd(args):
+    s3 = make_s3()
+    bucket = os.environ["R2_BUCKET"]
+    url = os.environ["EBD_TAR_URL"]
+
+    total_bytes = head_total_bytes(url)
+    basename = url.rsplit("/", 1)[-1]
+    if not basename.endswith(".tar"):
+        raise ValueError(f"URL must end in .tar: {basename}")
+    release = basename[: -len(".tar")]
+    raw_key = f"raw/{basename}"
+
+    # Skip if final object already exists at expected size
+    try:
+        head = s3.head_object(Bucket=bucket, Key=raw_key)
+        if head["ContentLength"] == total_bytes:
+            print(
+                f"R2 object r2://{bucket}/{raw_key} already complete "
+                f"({total_bytes:,} bytes); skipping multipart init."
+            )
+            write_gha_output(
+                {
+                    "already_complete": True,
+                    "total_bytes": total_bytes,
+                    "raw_key": raw_key,
+                    "release": release,
+                }
+            )
+            return
+    except s3.exceptions.ClientError:
+        pass
+
+    assignments, total_parts = compute_assignments(
+        total_bytes, args.part_size, args.shards
+    )
+
+    resp = s3.create_multipart_upload(Bucket=bucket, Key=raw_key)
+    upload_id = resp["UploadId"]
+
+    manifest = {
+        "upload_id": upload_id,
+        "raw_key": raw_key,
+        "release": release,
+        "total_bytes": total_bytes,
+        "part_size": args.part_size,
+        "total_parts": total_parts,
+        "total_shards": args.shards,
+        "shards": assignments,
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    manifest_key = f"parts-state/{upload_id}/manifest.json"
+    s3.put_object(
+        Bucket=bucket,
+        Key=manifest_key,
+        Body=json.dumps(manifest, indent=2).encode(),
+        ContentType="application/json",
+    )
+
+    print(f"Created multipart upload {upload_id}")
+    print(f"  total_bytes : {total_bytes:,}")
+    print(f"  total_parts : {total_parts}")
+    print(f"  part_size   : {args.part_size:,}")
+    print(f"  shards      : {args.shards}")
+    print(f"  manifest    : r2://{bucket}/{manifest_key}")
+    for a in assignments:
+        n = len(a["parts"])
+        first = a["parts"][0]["part_number"]
+        last = a["parts"][-1]["part_number"]
+        gb = (a["end_byte"] - a["start_byte"] + 1) / 1e9
+        print(
+            f"  shard {a['shard_index']}: parts {first}-{last} ({n} parts, {gb:.2f} GB)"
+        )
+
+    write_gha_output(
+        {
+            "already_complete": False,
+            "upload_id": upload_id,
+            "total_bytes": total_bytes,
+            "raw_key": raw_key,
+            "release": release,
+            "manifest_key": manifest_key,
+            "shards_json": json.dumps(list(range(args.shards))),
+        }
+    )
+
+
+# === shard ====================================================================
+
+
+def _read_manifest(s3, bucket: str, manifest_key: str) -> dict:
+    resp = s3.get_object(Bucket=bucket, Key=manifest_key)
+    return json.loads(resp["Body"].read())
+
+
+def _state_key(upload_id: str, part_number: int) -> str:
+    return f"parts-state/{upload_id}/{part_number:05d}.json"
+
+
+def shard_cmd(args):
+    s3 = make_s3()
+    bucket = os.environ["R2_BUCKET"]
+    url = os.environ["EBD_TAR_URL"]
+
+    manifest = _read_manifest(s3, bucket, args.manifest_key)
+    upload_id = manifest["upload_id"]
+    raw_key = manifest["raw_key"]
+    my_shard = manifest["shards"][args.shard_index]
+
+    parts = my_shard["parts"]
+    first_pn = parts[0]["part_number"]
+    last_pn = parts[-1]["part_number"]
+    total_size = my_shard["end_byte"] - my_shard["start_byte"] + 1
+    print(
+        f"Shard {args.shard_index}: parts {first_pn}-{last_pn} "
+        f"(bytes {my_shard['start_byte']:,}-{my_shard['end_byte']:,}, "
+        f"{total_size / 1e9:.2f} GB total)"
+    )
+
+    shard_t0 = time.monotonic()
+    bytes_done = 0
+
+    for part_info in parts:
+        part_num = part_info["part_number"]
+        start = part_info["start_byte"]
+        end = part_info["end_byte"]
+        expected_size = part_info["size"]
+        state_key = _state_key(upload_id, part_num)
+
+        # Skip if already uploaded
+        try:
+            existing = s3.get_object(Bucket=bucket, Key=state_key)
+            data = json.loads(existing["Body"].read())
+            if (
+                data.get("part_number") == part_num
+                and data.get("size") == expected_size
+            ):
+                print(f"  [{part_num:>5}] already uploaded; skipping")
+                bytes_done += expected_size
+                continue
+        except s3.exceptions.ClientError:
+            pass
+
+        # Stream-download to a temp file
+        with tempfile.NamedTemporaryFile(
+            prefix=f"ebd-part-{part_num:05d}-", delete=False
+        ) as tmp:
+            tmp_path = tmp.name
+        try:
+            t0 = time.monotonic()
+            req = Request(url, headers={"Range": f"bytes={start}-{end}"})
+            with urlopen(req, timeout=300) as resp, open(tmp_path, "wb") as out:
+                shutil.copyfileobj(resp, out, length=8 << 20)
+            actual_size = os.path.getsize(tmp_path)
+            if actual_size != expected_size:
+                raise RuntimeError(
+                    f"Part {part_num}: got {actual_size} bytes, expected {expected_size}"
+                )
+            dl_secs = time.monotonic() - t0
+            dl_mbps = actual_size / 1e6 / max(dl_secs, 1e-9)
+            print(
+                f"  [{part_num:>5}] downloaded {actual_size:,} B "
+                f"in {dl_secs:.1f}s ({dl_mbps:.2f} MB/s)"
+            )
+
+            # Upload as a part
+            t1 = time.monotonic()
+            with open(tmp_path, "rb") as f:
+                upload_resp = s3.upload_part(
+                    Bucket=bucket,
+                    Key=raw_key,
+                    UploadId=upload_id,
+                    PartNumber=part_num,
+                    Body=f,
+                    ContentLength=actual_size,
+                )
+            up_secs = time.monotonic() - t1
+            up_mbps = actual_size / 1e6 / max(up_secs, 1e-9)
+            etag = upload_resp["ETag"]
+            print(
+                f"  [{part_num:>5}] uploaded part in {up_secs:.1f}s "
+                f"({up_mbps:.2f} MB/s) etag={etag}"
+            )
+
+            # Persist state
+            state = {
+                "part_number": part_num,
+                "etag": etag,
+                "size": actual_size,
+                "shard_index": args.shard_index,
+                "uploaded_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            }
+            s3.put_object(
+                Bucket=bucket,
+                Key=state_key,
+                Body=json.dumps(state).encode(),
+                ContentType="application/json",
+            )
+            bytes_done += actual_size
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
+
+    elapsed = time.monotonic() - shard_t0
+    avg_mbps = bytes_done / 1e6 / max(elapsed, 1e-9)
+    print(
+        f"Shard {args.shard_index} complete: {bytes_done:,} B in "
+        f"{elapsed:.1f}s ({avg_mbps:.2f} MB/s avg)"
+    )
+
+
+# === complete =================================================================
+
+
+def complete_cmd(args):
+    s3 = make_s3()
+    bucket = os.environ["R2_BUCKET"]
+
+    manifest = _read_manifest(s3, bucket, args.manifest_key)
+    upload_id = manifest["upload_id"]
+    raw_key = manifest["raw_key"]
+    total_parts = manifest["total_parts"]
+    total_bytes = manifest["total_bytes"]
+
+    # Gather all part-state objects
+    parts: list[dict] = []
+    paginator = s3.get_paginator("list_objects_v2")
+    prefix = f"parts-state/{upload_id}/"
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            if obj["Key"].endswith("manifest.json"):
+                continue
+            resp = s3.get_object(Bucket=bucket, Key=obj["Key"])
+            state = json.loads(resp["Body"].read())
+            parts.append({"PartNumber": state["part_number"], "ETag": state["etag"]})
+
+    parts.sort(key=lambda p: p["PartNumber"])
+    if len(parts) != total_parts:
+        present = {p["PartNumber"] for p in parts}
+        missing = sorted(set(range(1, total_parts + 1)) - present)
+        raise RuntimeError(
+            f"Expected {total_parts} parts, found {len(parts)}. Missing: "
+            f"{missing[:20]}{' ...' if len(missing) > 20 else ''}"
+        )
+
+    print(f"Completing multipart upload {upload_id} with {len(parts)} parts...")
+    s3.complete_multipart_upload(
+        Bucket=bucket,
+        Key=raw_key,
+        UploadId=upload_id,
+        MultipartUpload={"Parts": parts},
+    )
+
+    head = s3.head_object(Bucket=bucket, Key=raw_key)
+    if head["ContentLength"] != total_bytes:
+        raise RuntimeError(
+            f"Final object size {head['ContentLength']:,} != expected {total_bytes:,}"
+        )
+    print(
+        f"✓ r2://{bucket}/{raw_key} assembled: {head['ContentLength']:,} B, "
+        f"etag={head['ETag']}"
+    )
+
+    # Cleanup parts-state
+    deleted = 0
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        keys = [{"Key": obj["Key"]} for obj in page.get("Contents", [])]
+        if keys:
+            s3.delete_objects(Bucket=bucket, Delete={"Objects": keys})
+            deleted += len(keys)
+    print(f"Cleaned up {deleted} parts-state object(s) under {prefix}")
+
+
+# === entrypoint ===============================================================
+
+
+def main():
+    p = argparse.ArgumentParser()
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    init_p = sub.add_parser("init", help="Create multipart upload + manifest")
+    init_p.add_argument("--shards", type=int, default=3)
+    init_p.add_argument(
+        "--part-size",
+        type=int,
+        default=5_000_000_000,
+        help="Bytes per part (default 5 GB; max 5 GB per S3 spec)",
+    )
+    init_p.set_defaults(func=init_cmd)
+
+    shard_p = sub.add_parser("shard", help="Download a shard's parts and upload them")
+    shard_p.add_argument("--manifest-key", required=True)
+    shard_p.add_argument("--shard-index", type=int, required=True)
+    shard_p.set_defaults(func=shard_cmd)
+
+    complete_p = sub.add_parser("complete", help="Complete the multipart upload")
+    complete_p.add_argument("--manifest-key", required=True)
+    complete_p.set_defaults(func=complete_cmd)
+
+    args = p.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

New `.github/workflows/ebd-raw-mirror.yml` + `src/cloaca/swan_lake/scripts/ebd_multipart.py`. Three GHA jobs (`init` → matrix `shard` → `complete`) cooperatively assemble a single R2 object from byte ranges downloaded in parallel by N runners.

The trick: S3 multipart upload's part assembly is byte-exact concatenation in `PartNumber` order. So if N runners each download a contiguous byte range from eBird and upload it as a span of parts, `complete_multipart_upload` produces an object byte-identical to the source `.tar` — no post-processing reassembly.

The bandwidth probe (PR #39) established that GHA runners get distinct Azure egress IPs and that eBird's per-IP cap means parallel downloaders give linear throughput scaling. With 3 shards we expect ~3× speedup, dropping the raw-mirror wallclock from ~7.5h to ~2.5h.

## Files

- `src/cloaca/swan_lake/scripts/ebd_multipart.py` — `init` / `shard` / `complete` subcommands. Reads URL + R2 creds from env. ~280 lines.
- `.github/workflows/ebd-raw-mirror.yml` — workflow_dispatch only; defaults to 3 shards × 5 GB parts (47 parts for the 232 GB tar). URL via `secrets.EBD_TAR_URL`, optional override input.

## Resume / idempotency

- Each part's ETag is persisted to `r2://<bucket>/parts-state/<UploadId>/<NNNNN>.json` immediately on upload.
- A re-dispatched shard checks for existing state files and skips parts already uploaded.
- If the final R2 object already exists at the expected size, `init` short-circuits and the rest of the workflow is skipped.
- After successful completion, parts-state objects are cleaned up.
- Suggest setting an R2 lifecycle rule to abort incomplete multipart uploads older than ~7 days, otherwise interrupted runs leave billable garbage.

## Security

- URL is sourced from `secrets.EBD_TAR_URL` (set in this repo as part of the URL-scrub work) and never echoed in run logs. The `shard` step prints byte ranges but not the URL.
- All `${{ inputs.* }}` values are passed via env vars, not interpolated into shell commands (per the GitHub Actions injection-prevention pattern from PR #38's review).

## Test plan

- [ ] Merge
- [ ] Dispatch with defaults (3 shards). Expect ~2.5h wallclock total: ~5 min init, ~2.5h parallel shards (each running ~16 parts × 5 GB / ~8.5 MB/s ≈ ~2.5h), ~2 min complete.
- [ ] Confirm `r2://ebd/raw/ebd_relMar-2026.tar` exists at exactly 232,356,454,400 bytes.
- [ ] Confirm `parts-state/<UploadId>/` is cleaned up.
- [ ] Try a re-dispatch — should short-circuit on `init` because object already exists.

## Out of scope (future work)

- Stage 2 (decompress + parse from R2 to Parquet) is a separate pipeline; this PR only handles getting the raw `.tar` into R2.
- Cron schedule. For now, manual `workflow_dispatch` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)