### PR TITLE
Multipart-mirror follow-ups: PYTHONUNBUFFERED, longer timeout, resume in-progress uploads

### DIFF
--- a/.github/workflows/ebd-raw-mirror.yml
+++ b/.github/workflows/ebd-raw-mirror.yml
@@ -43,6 +43,7 @@ jobs:
       manifest_key: ${{ steps.init.outputs.manifest_key }}
       shards_json: ${{ steps.init.outputs.shards_json }}
     env:
+      PYTHONUNBUFFERED: "1"
       EBD_TAR_URL: ${{ inputs.url_override || secrets.EBD_TAR_URL }}
       R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
       R2_BUCKET: ${{ secrets.R2_BUCKET }}
@@ -67,7 +68,7 @@ jobs:
     needs: init
     if: needs.init.outputs.already_complete != 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 240
+    timeout-minutes: 350
 
     strategy:
       fail-fast: false
@@ -75,6 +76,7 @@ jobs:
         shard: ${{ fromJSON(needs.init.outputs.shards_json) }}
 
     env:
+      PYTHONUNBUFFERED: "1"
       EBD_TAR_URL: ${{ inputs.url_override || secrets.EBD_TAR_URL }}
       R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
       R2_BUCKET: ${{ secrets.R2_BUCKET }}
@@ -111,6 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
+      PYTHONUNBUFFERED: "1"
       R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
       R2_BUCKET: ${{ secrets.R2_BUCKET }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}

--- a/src/cloaca/swan_lake/scripts/ebd_multipart.py
+++ b/src/cloaca/swan_lake/scripts/ebd_multipart.py
@@ -202,37 +202,95 @@ def init_cmd(args):
         if code not in ("404", "NoSuchKey", "NotFound"):
             raise
 
-    assignments, total_parts = compute_assignments(
-        total_bytes, args.part_size, args.shards
-    )
+    # Resume an in-progress multipart upload on the same key, if one exists
+    # and its manifest is intact. The manifest lives at
+    # parts-state/<UploadId>/manifest.json and was written when the prior init
+    # ran; reusing it preserves the byte-range / part-number assignments so
+    # already-uploaded parts (also in parts-state/<UploadId>/<NNNNN>.json) can
+    # be skipped on the resumed shard runs.
+    upload_id = None
+    assignments = None
+    total_parts = None
+    try:
+        resp = s3.list_multipart_uploads(Bucket=bucket, Prefix=raw_key)
+        candidates = sorted(
+            (u for u in resp.get("Uploads", []) if u["Key"] == raw_key),
+            key=lambda u: u["Initiated"],
+            reverse=True,
+        )
+    except s3.exceptions.ClientError:
+        candidates = []
+    for c in candidates:
+        candidate_id = c["UploadId"]
+        manifest_key_try = f"parts-state/{candidate_id}/manifest.json"
+        try:
+            existing = s3.get_object(Bucket=bucket, Key=manifest_key_try)
+            existing_manifest = json.loads(existing["Body"].read())
+        except s3.exceptions.ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            if code not in ("404", "NoSuchKey", "NotFound"):
+                raise
+            print(
+                f"  in-progress upload {candidate_id} has no manifest; "
+                f"aborting it so we can start fresh"
+            )
+            try:
+                s3.abort_multipart_upload(
+                    Bucket=bucket, Key=raw_key, UploadId=candidate_id
+                )
+            except Exception:
+                pass
+            continue
+        if existing_manifest.get("total_bytes") != total_bytes:
+            print(
+                f"  in-progress upload {candidate_id} manifest disagrees on "
+                f"total_bytes ({existing_manifest.get('total_bytes')} vs "
+                f"current {total_bytes}); aborting it"
+            )
+            try:
+                s3.abort_multipart_upload(
+                    Bucket=bucket, Key=raw_key, UploadId=candidate_id
+                )
+            except Exception:
+                pass
+            continue
+        upload_id = candidate_id
+        assignments = existing_manifest["shards"]
+        total_parts = existing_manifest["total_parts"]
+        print(
+            f"Resuming in-progress multipart upload {upload_id} "
+            f"({existing_manifest['total_shards']} shards, {total_parts} parts)"
+        )
+        break
 
-    resp = s3.create_multipart_upload(Bucket=bucket, Key=raw_key)
-    upload_id = resp["UploadId"]
+    if upload_id is None:
+        assignments, total_parts = compute_assignments(
+            total_bytes, args.part_size, args.shards
+        )
+        resp = s3.create_multipart_upload(Bucket=bucket, Key=raw_key)
+        upload_id = resp["UploadId"]
+        manifest = {
+            "upload_id": upload_id,
+            "raw_key": raw_key,
+            "release": release,
+            "total_bytes": total_bytes,
+            "part_size": args.part_size,
+            "total_parts": total_parts,
+            "total_shards": args.shards,
+            "shards": assignments,
+            "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        }
+        s3.put_object(
+            Bucket=bucket,
+            Key=f"parts-state/{upload_id}/manifest.json",
+            Body=json.dumps(manifest, indent=2).encode(),
+            ContentType="application/json",
+        )
+        print(f"Created multipart upload {upload_id}")
 
-    manifest = {
-        "upload_id": upload_id,
-        "raw_key": raw_key,
-        "release": release,
-        "total_bytes": total_bytes,
-        "part_size": args.part_size,
-        "total_parts": total_parts,
-        "total_shards": args.shards,
-        "shards": assignments,
-        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-    }
     manifest_key = f"parts-state/{upload_id}/manifest.json"
-    s3.put_object(
-        Bucket=bucket,
-        Key=manifest_key,
-        Body=json.dumps(manifest, indent=2).encode(),
-        ContentType="application/json",
-    )
-
-    print(f"Created multipart upload {upload_id}")
     print(f"  total_bytes : {total_bytes:,}")
     print(f"  total_parts : {total_parts}")
-    print(f"  part_size   : {args.part_size:,}")
-    print(f"  shards      : {args.shards}")
     print(f"  manifest    : r2://{bucket}/{manifest_key}")
     for a in assignments:
         n = len(a["parts"])
@@ -251,7 +309,9 @@ def init_cmd(args):
             "raw_key": raw_key,
             "release": release,
             "manifest_key": manifest_key,
-            "shards_json": json.dumps(list(range(args.shards))),
+            # On resume the shard count comes from the existing manifest, not
+            # args.shards, so use the actual assignment length.
+            "shards_json": json.dumps(list(range(len(assignments)))),
         }
     )
 


### PR DESCRIPTION
## Summary

Three small fixes to `ebd-raw-mirror` based on observations from the first production run (PR #42, run 25515250419).

## Changes

1. **`PYTHONUNBUFFERED: "1"`** in every job's `env:` block. Without it, Python's `print()` is block-buffered when stdout is a CI pipe, so per-part progress lines pile up in an 8 KB buffer and the GHA UI shows no output for ~20 min at a time. With it, each line streams to the runner immediately.

2. **Shard `timeout-minutes` 240 → 350.** The first production run came in at 3h 41m, comfortably under the old 4h cap, but with little headroom. 350 (just under GHA's 360-minute hard cap) makes us robust to slower months.

3. **`init` resumes an existing in-progress multipart upload** when one is found on the same R2 key with an intact manifest at `parts-state/<UploadId>/manifest.json`. Fixes the cross-run-resume gap we identified: previously, if shards died mid-upload and the workflow was re-dispatched, init would create a fresh UploadId and the parts-state files from the first attempt would be ignored. Aborts orphaned multiparts whose manifests are missing or disagree on `total_bytes`.

## Verified

- Script `--help` parses cleanly after the changes.
- Resume path is reachable: `list_multipart_uploads(Bucket, Prefix=raw_key)` returns Uploads filtered to the matching Key, sorted by Initiated time, most-recent-first. We try each candidate's manifest; first valid one wins.

Not tested end-to-end — the most-recent run cleaned up parts-state, so there's no in-progress upload to resume against. The codepath is small and the assertions are explicit.

## Test plan

- [ ] Merge
- [ ] (Optional) dispatch the workflow to confirm init still works on the happy path (raw object already in R2, so `already_complete=true` short-circuit fires; ~10s run).
- [ ] (Optional) simulate the resume path by aborting all multiparts in R2 manually, then dispatching to confirm a fresh init creates a new upload — and a second dispatch resumes that upload's manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)